### PR TITLE
Make server documentation work for Ubuntu 20.04

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -40,9 +40,9 @@ apt install -y \
   imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev file git-core \
   g++ libprotobuf-dev protobuf-compiler pkg-config nodejs gcc autoconf \
   bison build-essential libssl-dev libyaml-dev libreadline6-dev \
-  zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev \
+  zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev \
   nginx redis-server redis-tools postgresql postgresql-contrib \
-  certbot python-certbot-nginx yarn libidn11-dev libicu-dev libjemalloc-dev
+  certbot python3-certbot-nginx yarn libidn11-dev libicu-dev libjemalloc-dev
 ```
 
 ### Installing Ruby {#installing-ruby}


### PR DESCRIPTION
I'm on 20.04 LTS (Focal Fossa) and setting up a new Mastodon instance. Found that following the instructions on https://docs.joinmastodon.org/admin/install/ -- which mentions ubuntu 18.04 -- mostly worked as written, but I had to apt install slightly different library versions than those listed. Here is a corrected version that worked for me.

Since 20.04 is the latest LTS release, I propose the main documentation page should be written to work for this version.