### PR TITLE
Update install and backup pages

### DIFF
--- a/content/en/admin/backups.md
+++ b/content/en/admin/backups.md
@@ -52,3 +52,7 @@ If you are using local file storage, then it’s up to you to make copies of the
 
 Backing up Redis is easy. Redis regularly writes to `/var/lib/redis/dump.rdb` which is the only file you need to make a copy of.
 
+
+## Let's Encrypt files {#letsencrypt}
+
+Backing up Let's Encrypt key file, certificate files, and account credentials is just as easy; make a secure copy of the `/etc/letsencrypt`. Do this as soon as the certificate gets renewed by certbot.

--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -183,6 +183,10 @@ Then edit `/etc/nginx/sites-available/mastodon` to replace `example.com` with yo
 
 Reload nginx for the changes to take effect:
 
+```bash
+service nginx restart
+```
+
 ### Acquiring a SSL certificate {#acquiring-a-ssl-certificate}
 
 We’ll use Let’s Encrypt to get a free SSL certificate:
@@ -222,4 +226,3 @@ They will now automatically start at boot time.
 {{< hint style="success" >}}
 **Hurray! This is it. You can visit your domain in the browser now!**
 {{< /hint >}}
-


### PR DESCRIPTION
- Backing up should include Let's Encrypt files in /etc/letsencrypt, since this is part of the installation procedure and certbot tells you to back it up.
- The installation instructions tells you to restart nginx, doesn't tell you how to do this.

I made these two commits to resolve these two miner issues.