### PR TITLE
Fix link to tootctl

### DIFF
--- a/content/en/admin/troubleshooting/index-corruption.md
+++ b/content/en/admin/troubleshooting/index-corruption.md
@@ -82,7 +82,7 @@ Mastodon 3.2.2 and later come with a semi-interactive script to fix those corrup
 Before attempting to fix your database, stop Mastodon and make a backup of your database. Then, with Mastodon still stopped, run the maintenance script:
 
 ```
-RAILS_ENV=production tootctl maintenance fix-duplicates
+RAILS_ENV=production bin/tootctl maintenance fix-duplicates
 ```
 
 The tool will walk through the database to find duplicate and fix them. In some cases, those operations are destructive. In the most destructive cases, you will be asked to chose which record to keep. In all cases, walking through the whole database in search of duplicates is an extremely long operation. Mastodon **has** to be stopped during the whole process to prevent additional duplicates from occuring.


### PR DESCRIPTION
Assuming that this documentation is run inside the /live (Mastodon home directory), the current link is broken. 

The proposed change fixes this error and thus refers to the tootctl inside the bin directory