### PR TITLE
Do not build Ruby with jemalloc

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -73,7 +73,7 @@ git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 Once this is done, we can install the correct Ruby version:
 
 ```bash
-RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install 2.7.2
+rbenv install 2.7.2
 rbenv global 2.7.2
 ```
 


### PR DESCRIPTION
**NOTE**: This must be merged after https://github.com/tootsuite/mastodon/pull/16462 is released, or jemalloc will be disabled. This pull request is complete but I mark this as draft until https://github.com/tootsuite/mastodon/pull/16462 gets merged.

Always mark jemalloc needed if jemalloc is enabled by akihikodaki · Pull Request #4627 · ruby/ruby
https://github.com/ruby/ruby/pull/4627
> Symbols exported by jemalloc is referred by the shared library but not by the executables when building Ruby as a shared library with jemalloc. It causes shared libraries such as the GNU C++ library occasionally rely on the memory allocator provided by the standard C library. Worse, the resolved symbols can later be replaced with jemalloc, and jemalloc may see pointers from the standard C library, which results in various failures. e.g. https://github.com/tootsuite/mastodon/issues/15751

As a workaround, do not rely on jemalloc enablement of Ruby, and preload `libjemalloc.so` instead.

Always mark jemalloc needed so that memory allocator symbols of other shared libraries are also resolved with jemalloc.