### PR TITLE
Fix `force_login` type & more

### DIFF
--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -30,9 +30,6 @@ Bearer &lt;app token&gt;
 {{< endapi-method-parameter >}}
 {{< endapi-method-headers >}}
 {{< api-method-form-data-parameters >}}
-{{< api-method-parameter name="reason" type="string" required=false >}}
-Text that will be reviewed by moderators if registrations require manual approval.
-{{< endapi-method-parameter >}}
 {{< api-method-parameter name="username" type="string" required=true >}}
 The desired username for the account
 {{< endapi-method-parameter >}}
@@ -47,6 +44,9 @@ Whether the user agrees to the local rules, terms, and policies. These should be
 {{< endapi-method-parameter >}}
 {{< api-method-parameter name="locale" type="string" required=true >}}
 The language of the confirmation email that will be sent
+{{< endapi-method-parameter >}}
+{{< api-method-parameter name="reason" type="string" required=false >}}
+Text that will be reviewed by moderators if registrations require manual approval.
 {{< endapi-method-parameter >}}
 {{< endapi-method-form-data-parameters >}}
 {{< endapi-method-request >}}
@@ -711,10 +711,13 @@ Bearer &lt;app token&gt;
 {{< endapi-method-headers >}}
 {{< api-method-query-parameters >}}
 {{< api-method-parameter name="max_id" type="string" required=false >}}
+**Internal parameter.** Use HTTP `Link` header for pagination.
 {{< endapi-method-parameter >}}
 {{< api-method-parameter name="since_id" type="string" required=false >}}
+**Internal parameter.** Use HTTP `Link` header for pagination.
 {{< endapi-method-parameter >}}
 {{< api-method-parameter name="limit" type="number" required=false >}}
+Maximum number of results to return. Defaults to 40.
 {{< endapi-method-parameter >}}
 {{< endapi-method-query-parameters >}}
 {{< endapi-method-request >}}
@@ -783,7 +786,8 @@ Invalid or missing Authorization header, or instance is in whitelist mode and yo
 
 
 {{< tabs >}}
-{{< tab title="header" >}}
+{{< tab titl
+e="header" >}}
 ```javascript
 {
   "error": "The access token is invalid"
@@ -857,7 +861,7 @@ Bearer &lt;app token&gt;
 {{< api-method-parameter name="since_id" type="string" required=false >}}
 **Internal parameter.** Use HTTP `Link` header for pagination.
 {{< endapi-method-parameter >}}
-{{< api-method-parameter name="limit" type="string" required=false >}}
+{{< api-method-parameter name="limit" type="number" required=false >}}
 Maximum number of results to return. Defaults to 40.
 {{< endapi-method-parameter >}}
 {{< endapi-method-query-parameters >}}
@@ -1981,7 +1985,7 @@ Bearer &lt;user token&gt;
 {{< api-method-parameter name="q" type="string" required=true >}}
 What to search for
 {{< endapi-method-parameter >}}
-{{< api-method-parameter name="limit" type="string" required=false >}}
+{{< api-method-parameter name="limit" type="number" required=false >}}
 Maximum number of results. Defaults to 40.
 {{< endapi-method-parameter >}}
 {{< api-method-parameter name="resolve" type="string" required=false >}}

--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -786,8 +786,7 @@ Invalid or missing Authorization header, or instance is in whitelist mode and yo
 
 
 {{< tabs >}}
-{{< tab titl
-e="header" >}}
+{{< tab title="header" >}}
 ```javascript
 {
   "error": "The access token is invalid"

--- a/content/en/methods/apps/oauth.md
+++ b/content/en/methods/apps/oauth.md
@@ -16,9 +16,6 @@ Displays an authorization form to the user. If approved, it will create and retu
 {{< api-method-spec >}}
 {{< api-method-request >}}
 {{< api-method-form-data-parameters >}}
-{{< api-method-parameter name="force_login" type="string" required=false >}}
-Added in 2.6.0. Forces the user to re-login, which is necessary for authorizing with multiple accounts from the same instance.
-{{< endapi-method-parameter >}}
 {{< api-method-parameter name="response_type" type="string" required=true >}}
 Should be set equal to `code`.
 {{< endapi-method-parameter >}}
@@ -30,6 +27,9 @@ Set a URI to redirect the user to. If this parameter is set to `urn:ietf:wg:oaut
 {{< endapi-method-parameter >}}
 {{< api-method-parameter name="scope" type="string" required=false >}}
 List of requested OAuth scopes, separated by spaces \(or by pluses, if using query parameters\). Must be a subset of scopes declared during app registration. If not provided, defaults to `read`.
+{{< endapi-method-parameter >}}
+{{< api-method-parameter name="force_login" type="bool" required=false >}}
+Added in 2.6.0. Forces the user to re-login, which is necessary for authorizing with multiple accounts from the same instance.
 {{< endapi-method-parameter >}}
 {{< endapi-method-form-data-parameters >}}
 {{< endapi-method-request >}}
@@ -71,6 +71,9 @@ Returns an access token, to be used during API calls that are not public.
 {{< api-method-spec >}}
 {{< api-method-request >}}
 {{< api-method-form-data-parameters >}}
+{{< api-method-parameter name="grant_type" type="string" required=true >}}
+Set equal to `authorization_code` if `code` is provided in order to gain user-level access. Otherwise, set equal to `client_credentials` to obtain app-level access only.
+{{< endapi-method-parameter >}}
 {{< api-method-parameter name="client_id" type="string" required=true >}}
 Client ID, obtained during app registration
 {{< endapi-method-parameter >}}
@@ -85,9 +88,6 @@ List of requested OAuth scopes, separated by spaces. Must be a subset of scopes 
 {{< endapi-method-parameter >}}
 {{< api-method-parameter name="code" type="string" required=false >}}
 A user authorization code, obtained via /oauth/authorize
-{{< endapi-method-parameter >}}
-{{< api-method-parameter name="grant_type" type="string" required=true >}}
-Set equal to `authorization_code` if `code` is provided in order to gain user-level access. Otherwise, set equal to `client_credentials` to obtain app-level access only.
 {{< endapi-method-parameter >}}
 {{< endapi-method-form-data-parameters >}}
 {{< endapi-method-request >}}


### PR DESCRIPTION
This PR ..
- makes `force_login` of type `bool`
- makes `limit` of type `number`
- moves optional parameters to bottom of table for consistency
- adds missing descriptions