### PR TITLE
Fix package name for certbot-nginx

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -42,7 +42,7 @@ apt install -y \
   bison build-essential libssl-dev libyaml-dev libreadline6-dev \
   zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev \
   nginx redis-server redis-tools postgresql postgresql-contrib \
-  certbot python-certbot-nginx yarn libidn11-dev libicu-dev libjemalloc-dev
+  certbot python3-certbot-nginx yarn libidn11-dev libicu-dev libjemalloc-dev
 ```
 
 ### Installing Ruby {#installing-ruby}


### PR DESCRIPTION
python-certbot-nginx does not exist anymore in Debian.