### PR TITLE
fix(libraries): Mark all Rust libraries as unmaintained and fix link to Elefren

### DIFF
--- a/content/en/client/libraries.md
+++ b/content/en/client/libraries.md
@@ -95,8 +95,8 @@ menu:
 
 ## Rust {#rust}
 
-* [mammut](https://github.com/Aaronepower/mammut)
-* [elefren](https://github.com/pwoolcoc/elefren)
+* [mammut](https://github.com/Aaronepower/mammut) (unmaintained)
+* [elefren](https://github.com/DeeUnderscore/elefren) (unmaintained)
 
 ## Scala {#scala}
 


### PR DESCRIPTION
Problem: both Rust client library integrations are unmaintained now. They only work with old HTTP library versions (Tokio), which is a bit problematic.

The Elefren library was also deleted by the original author, fixed the link for that.