### PR TITLE
Replace 'tootsuite' in GitHub links with 'mastodon'

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -140,7 +140,7 @@ su - mastodon
 Use git to download the latest stable release of Mastodon:
 
 ```bash
-git clone https://github.com/tootsuite/mastodon.git live && cd live
+git clone https://github.com/mastodon/mastodon.git live && cd live
 git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)
 ```
 
@@ -214,7 +214,7 @@ Copy the systemd service templates from the Mastodon directory:
 cp /home/mastodon/live/dist/mastodon-*.service /etc/systemd/system/
 ```
 
-If you deviated from the defaults at any point, check that the username and paths are correct: 
+If you deviated from the defaults at any point, check that the username and paths are correct:
 
 ```sh
 $EDITOR /etc/systemd/system/mastodon-*.service

--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -22,7 +22,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## Base CLI
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/cli.rb" caption="lib/cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/cli.rb" caption="lib/cli.rb" >}}
 
 ### `tootctl self-destruct` {#self-destruct}
 
@@ -50,7 +50,7 @@ Show the version of the currently running Mastodon instance.
 
 ## Accounts CLI {#accounts}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/accounts_cli.rb" caption="lib/mastodon/accounts\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/accounts_cli.rb" caption="lib/mastodon/accounts\_cli.rb" >}}
 
 ### `tootctl accounts rotate` {#accounts-rotate}
 
@@ -221,7 +221,7 @@ Approve new registrations when instance is in approval mode.
 
 ## Cache CLI {#cache}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/cache_cli.rb" caption="lib/mastodon/cache\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/cache_cli.rb" caption="lib/mastodon/cache\_cli.rb" >}}
 
 ### `tootctl cache clear` {#cache-clear}
 
@@ -245,7 +245,7 @@ Update hard-cached counters of TYPE by counting referenced records from scratch.
 
 ## Domains CLI {#domains}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/domains_cli.rb" caption="lib/mastodon/domains\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/domains_cli.rb" caption="lib/mastodon/domains\_cli.rb" >}}
 
 ### `tootctl domains purge` {#domains-purge}
 
@@ -283,7 +283,7 @@ Crawl the known fediverse by using Mastodon REST API endpoints that expose all k
 
 ## Email domain blocks CLI {#email-domain-blocks}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/email_domain_blocks_cli.rb" caption="lib/mastodon/email\_domain\_blocks\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/email_domain_blocks_cli.rb" caption="lib/mastodon/email\_domain\_blocks\_cli.rb" >}}
 
 ### `tootctl email-domain-blocks list` {#email-domain-blocks-list}
 
@@ -317,7 +317,7 @@ Remove entries from the e-mail domain blocklist.
 
 ## Emoji CLI {#emoji}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/emoji_cli.rb" caption="lib/mastodon/emoji\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/emoji_cli.rb" caption="lib/mastodon/emoji\_cli.rb" >}}
 
 ### `tootctl emoji export` {#emoji-export}
 
@@ -362,7 +362,7 @@ Remove all custom emoji.
 
 ## Feeds CLI {#feeds}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/feeds_cli.rb" caption="lib/mastodon/feeds\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/feeds_cli.rb" caption="lib/mastodon/feeds\_cli.rb" >}}
 
 ### `tootctl feeds build` {#feeds-build}
 
@@ -388,7 +388,7 @@ Remove all home and list feeds from Redis.
 
 ## Maintenance CLI {#maintenance}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/maintenance_cli.rb" caption="lib/mastodon/maintenance\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/maintenance_cli.rb" caption="lib/mastodon/maintenance\_cli.rb" >}}
 
 ### `tootctl maintenance fix-duplicates` {#maintenance-fix-duplicates}
 
@@ -396,7 +396,7 @@ Fix corrupted database indexes that may have been caused due to changing collati
 
 ## Media CLI {#media}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/media_cli.rb" caption="lib/mastodon/media\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/media_cli.rb" caption="lib/mastodon/media\_cli.rb" >}}
 
 ### `tootctl media remove` {#media-remove}
 
@@ -463,7 +463,7 @@ Prompts for a media URL, then looks up where the media is displayed.
 
 ## Preview Cards CLI {#preview_cards}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/preview_cards_cli.rb" caption="lib/mastodon/preview\_cards\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/preview_cards_cli.rb" caption="lib/mastodon/preview\_cards\_cli.rb" >}}
 
 ### `tootctl preview_cards remove` {#preview_cards-remove}
 
@@ -482,7 +482,7 @@ Remove local thumbnails for preview cards.
 
 ## Search CLI {#search}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/search_cli.rb" caption="lib/mastodon/search\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/search_cli.rb" caption="lib/mastodon/search\_cli.rb" >}}
 
 ### `tootctl search deploy` {#search-deploy}
 
@@ -501,7 +501,7 @@ Create or update an ElasticSearch index and populate it. If ElasticSearch is emp
 
 ## Settings CLI {#settings}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/settings_cli.rb" caption="lib/mastodon/settings\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/settings_cli.rb" caption="lib/mastodon/settings\_cli.rb" >}}
 
 ### `tootctl settings registrations open` {#settings-registrations-open}
 
@@ -519,7 +519,7 @@ Closes registrations.
 
 ## Statuses CLI {#statuses}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/statuses_cli.rb" caption="lib/mastodon/statuses\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/statuses_cli.rb" caption="lib/mastodon/statuses\_cli.rb" >}}
 
 ### `tootctl statuses remove` {#statuses-remove}
 
@@ -538,7 +538,7 @@ This is a computationally heavy procedure that creates extra database indices be
 
 ## Upgrade CLI {#upgrade}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/upgrade_cli.rb" caption="lib/mastodon/upgrade\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/upgrade_cli.rb" caption="lib/mastodon/upgrade\_cli.rb" >}}
 
 ### `tootctl upgrade storage-schema` {#upgrade-storage-schema}
 

--- a/content/en/admin/upgrading.md
+++ b/content/en/admin/upgrading.md
@@ -7,10 +7,10 @@ menu:
 ---
 
 {{< hint style="info" >}}
-When a new version of Mastodon comes out, it appears on the [GitHub releases page](https://github.com/tootsuite/mastodon/releases). Please mind that running unreleased code from the `master` branch, while possible, is not recommended.
+When a new version of Mastodon comes out, it appears on the [GitHub releases page](https://github.com/mastodon/mastodon/releases). Please mind that running unreleased code from the `master` branch, while possible, is not recommended.
 {{< /hint >}}
 
-Mastodon releases correspond to git tags. Before attempting an upgrade, look up the desired release on the [GitHub releases page](https://github.com/tootsuite/mastodon/releases). The page will contain a **changelog** describing everything you need to know about what's different, as well as **specific upgrade instructions**.
+Mastodon releases correspond to git tags. Before attempting an upgrade, look up the desired release on the [GitHub releases page](https://github.com/mastodon/mastodon/releases). The page will contain a **changelog** describing everything you need to know about what's different, as well as **specific upgrade instructions**.
 
 To begin, switch to the `mastodon` user:
 

--- a/content/en/api/oauth-scopes.md
+++ b/content/en/api/oauth-scopes.md
@@ -25,10 +25,10 @@ The set of scopes saved during app creation must include all the scopes that you
 
 - 0.9.0 - read, write, follow
 - 2.4.0 - push
-- 2.4.3 - granular scopes [https://github.com/tootsuite/mastodon/pull/7929](https://github.com/tootsuite/mastodon/pull/7929)
-- 2.6.0 - read:reports deprecated \(unused stub\) [https://github.com/tootsuite/mastodon/pull/8736/commits/adcf23f1d00c8ff6877ca2ee2af258f326ae4e1f](https://github.com/tootsuite/mastodon/pull/8736/commits/adcf23f1d00c8ff6877ca2ee2af258f326ae4e1f)
-- 2.6.0 - write:conversations added [https://github.com/tootsuite/mastodon/pull/9009](https://github.com/tootsuite/mastodon/pull/9009)
-- 2.9.1 - Admin scopes added [https://github.com/tootsuite/mastodon/pull/9387](https://github.com/tootsuite/mastodon/pull/9387)
+- 2.4.3 - granular scopes [https://github.com/mastodon/mastodon/pull/7929](https://github.com/mastodon/mastodon/pull/7929)
+- 2.6.0 - read:reports deprecated \(unused stub\) [https://github.com/mastodon/mastodon/pull/8736/commits/adcf23f1d00c8ff6877ca2ee2af258f326ae4e1f](https://github.com/mastodon/mastodon/pull/8736/commits/adcf23f1d00c8ff6877ca2ee2af258f326ae4e1f)
+- 2.6.0 - write:conversations added [https://github.com/mastodon/mastodon/pull/9009](https://github.com/mastodon/mastodon/pull/9009)
+- 2.9.1 - Admin scopes added [https://github.com/mastodon/mastodon/pull/9387](https://github.com/mastodon/mastodon/pull/9387)
 - 3.1.0 - Bookmark scopes added
 
 ## List of scopes

--- a/content/en/client/libraries.md
+++ b/content/en/client/libraries.md
@@ -91,7 +91,7 @@ menu:
 
 ## Ruby {#ruby}
 
-* [mastodon-api](https://github.com/tootsuite/mastodon-api)
+* [mastodon-api](https://github.com/mastodon/mastodon-api)
 
 ## Rust {#rust}
 

--- a/content/en/dev/routes.md
+++ b/content/en/dev/routes.md
@@ -7,7 +7,7 @@ menu:
     parent: dev
 ---
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/config/routes.rb" caption="config/routes.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/config/routes.rb" caption="config/routes.rb" >}}
 
 ## Explanation of routes {#routes}
 

--- a/content/en/entities/account.md
+++ b/content/en/entities/account.md
@@ -170,7 +170,7 @@ Equal to `header` if its value is a static image; different if `header` is an an
 **Version history:**\
 3.1.0 - added
 
-## Statistical attributes 
+## Statistical attributes
 
 ### `created_at` {#created_at}
 
@@ -257,7 +257,7 @@ Equal to `header` if its value is a static image; different if `header` is an an
 
 {{< page-ref page="methods/accounts.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/account_serializer.rb" caption="app/serializers/rest/account\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/account_serializer.rb" caption="app/serializers/rest/account\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/activity.md
+++ b/content/en/entities/activity.md
@@ -49,7 +49,7 @@ menu:
 
 {{< page-ref page="methods/instance.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/controllers/api/v1/instances/activity_controller.rb" caption="app/controllers/api/v1/instances/activity\_controller.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/controllers/api/v1/instances/activity_controller.rb" caption="app/controllers/api/v1/instances/activity\_controller.rb" >}}
 
 
 

--- a/content/en/entities/admin-account.md
+++ b/content/en/entities/admin-account.md
@@ -124,7 +124,7 @@ menu:
 
 {{< page-ref page="methods/admin.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/admin/account_serializer.rb" caption="app/serializers/rest/admin/account\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/admin/account_serializer.rb" caption="app/serializers/rest/admin/account\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/admin-report.md
+++ b/content/en/entities/admin-report.md
@@ -78,7 +78,7 @@ menu:
 
 {{< page-ref page="methods/admin.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/admin/report_serializer.rb" caption="app/serializers/rest/admin/report\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/admin/report_serializer.rb" caption="app/serializers/rest/admin/report\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/application.md
+++ b/content/en/entities/application.md
@@ -61,7 +61,7 @@ menu:
 
 {{< page-ref page="methods/apps.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/application_serializer.rb" caption="app/serializers/rest/application\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/application_serializer.rb" caption="app/serializers/rest/application\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/attachment.md
+++ b/content/en/entities/attachment.md
@@ -224,7 +224,7 @@ More importantly, there may be another top-level `focus` Hash object as of 2.3.0
 
 {{< page-ref page="methods/statuses/media.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/media_attachment_serializer.rb" caption="app/serializers/rest/media\_attachment\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/media_attachment_serializer.rb" caption="app/serializers/rest/media\_attachment\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/card.md
+++ b/content/en/entities/card.md
@@ -181,5 +181,5 @@ menu:
 
 {{< page-ref page="status.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/preview_card_serializer.rb" caption="app/serializers/rest/preview\_card\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/preview_card_serializer.rb" caption="app/serializers/rest/preview\_card\_serializer.rb" >}}
 

--- a/content/en/entities/context.md
+++ b/content/en/entities/context.md
@@ -60,7 +60,7 @@ menu:
 
 * [GET /api/v1/statuses/:id/context]({{< relref "../methods/statuses/#parent-and-child-statuses" >}})
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/context_serializer.rb" caption="app/serializers/rest/context\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/context_serializer.rb" caption="app/serializers/rest/context\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/conversation.md
+++ b/content/en/entities/conversation.md
@@ -62,7 +62,7 @@ menu:
 
 {{< page-ref page="methods/timelines/conversations.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/conversation_serializer.rb" caption="app/serializers/rest/conversation\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/conversation_serializer.rb" caption="app/serializers/rest/conversation\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/emoji.md
+++ b/content/en/entities/emoji.md
@@ -60,7 +60,7 @@ menu:
 
 {{< page-ref page="methods/instance/custom_emojis.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/custom_emoji_serializer.rb" caption="app/serializers/rest/custom\_emoji\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/custom_emoji_serializer.rb" caption="app/serializers/rest/custom\_emoji\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/error.md
+++ b/content/en/entities/error.md
@@ -79,7 +79,7 @@ Error: This method requires an authenticated user. Appears when using an OAuth t
 
 ## See also
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/controllers/api/base_controller.rb" caption="app/controllers/api/base\_controller.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/controllers/api/base_controller.rb" caption="app/controllers/api/base\_controller.rb" >}}
 
 
 

--- a/content/en/entities/featuredtag.md
+++ b/content/en/entities/featuredtag.md
@@ -53,7 +53,7 @@ menu:
 
 {{< page-ref page="methods/accounts/featured_tags.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/featured_tag_serializer.rb" caption="app/serializers/rest/featured\_tag\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/featured_tag_serializer.rb" caption="app/serializers/rest/featured\_tag\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/filter.md
+++ b/content/en/entities/filter.md
@@ -80,11 +80,11 @@ Please check `app/javascript/mastodon/selectors/index.js` and `app/lib/feed_mana
 
 {{< page-ref page="methods/accounts/filters.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/lib/feed_manager.rb" caption="app/lib/feed\_manager.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/lib/feed_manager.rb" caption="app/lib/feed\_manager.rb" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/javascript/mastodon/selectors/index.js" caption="app/javascript/mastodon/selectors/index.js" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/javascript/mastodon/selectors/index.js" caption="app/javascript/mastodon/selectors/index.js" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/filter_serializer.rb" caption="app/serializers/rest/filter\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/filter_serializer.rb" caption="app/serializers/rest/filter\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/history.md
+++ b/content/en/entities/history.md
@@ -42,7 +42,7 @@ menu:
 
 {{< page-ref page="tag.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/17159625b3e2c6d94509c0c2879ca80efbac6846/app/models/tag.rb\#L101-L115" caption="app/models/tag.rb L101-115 -- history days\[\]" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/17159625b3e2c6d94509c0c2879ca80efbac6846/app/models/tag.rb\#L101-L115" caption="app/models/tag.rb L101-115 -- history days\[\]" >}}
 
 
 

--- a/content/en/entities/identityproof.md
+++ b/content/en/entities/identityproof.md
@@ -54,7 +54,7 @@ menu:
 * /api/proofs
 * [About identity proofs]({{< relref "../user/contacts.md#identity-proofs" >}})
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/identity_proof_serializer.rb" caption="app/serializers/rest/identity\_proof\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/identity_proof_serializer.rb" caption="app/serializers/rest/identity\_proof\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/instance.md
+++ b/content/en/entities/instance.md
@@ -173,7 +173,7 @@ Domains federated with this instance. Number.
 
 {{< page-ref page="methods/instance.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/instance_serializer.rb" caption="app/serializers/rest/instance\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/instance_serializer.rb" caption="app/serializers/rest/instance\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/list.md
+++ b/content/en/entities/list.md
@@ -45,7 +45,7 @@ menu:
 
 {{< page-ref page="methods/timelines/lists.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/list_serializer.rb" caption="app/serializers/rest/list\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/list_serializer.rb" caption="app/serializers/rest/list\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/marker.md
+++ b/content/en/entities/marker.md
@@ -61,7 +61,7 @@ menu:
 
 {{< page-ref page="methods/timelines/markers.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/marker_serializer.rb" caption="app/serializers/rest/marker\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/marker_serializer.rb" caption="app/serializers/rest/marker\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/notification.md
+++ b/content/en/entities/notification.md
@@ -115,7 +115,7 @@ menu:
 
 {{< page-ref page="methods/notifications.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/notification_serializer.rb" caption="app/serializers/rest/notification\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/notification_serializer.rb" caption="app/serializers/rest/notification\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/poll.md
+++ b/content/en/entities/poll.md
@@ -113,7 +113,7 @@ The number of received votes for this option. Number, or null if results are not
 
 {{< page-ref page="methods/statuses/polls.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/poll_serializer.rb" caption="app/serializers/rest/poll\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/poll_serializer.rb" caption="app/serializers/rest/poll\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/preferences.md
+++ b/content/en/entities/preferences.md
@@ -65,7 +65,7 @@ menu:
 
 {{< page-ref page="methods/accounts/preferences.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/preferences_serializer.rb" caption="app/serializers/rest/preferences\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/preferences_serializer.rb" caption="app/serializers/rest/preferences\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/pushsubscription.md
+++ b/content/en/entities/pushsubscription.md
@@ -73,7 +73,7 @@ Receive a push notification when a poll you voted in or created has ended? Boole
 
 {{< page-ref page="methods/notifications/push.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/web_push_subscription_serializer.rb" caption="app/serializers/rest/web\_push\_subscription\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/web_push_subscription_serializer.rb" caption="app/serializers/rest/web\_push\_subscription\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/relationship.md
+++ b/content/en/entities/relationship.md
@@ -122,4 +122,4 @@ menu:
 
 * [GET /api/v1/accounts/relationships]({{< relref "../methods/accounts.md#check-relationships-to-other-accounts" >}})
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/relationship_serializer.rb" caption="app/serializers/rest/relationship\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/relationship_serializer.rb" caption="app/serializers/rest/relationship\_serializer.rb" >}}

--- a/content/en/entities/report.md
+++ b/content/en/entities/report.md
@@ -22,7 +22,7 @@ This page is currently under construction.
 
 {{< page-ref page="methods/accounts/reports.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/report_serializer.rb" caption="app/serializers/rest/report\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/report_serializer.rb" caption="app/serializers/rest/report\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/results.md
+++ b/content/en/entities/results.md
@@ -107,7 +107,7 @@ menu:
 
 {{< page-ref page="methods/search.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/search_serializer.rb" caption="app/serializers/rest/search\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/search_serializer.rb" caption="app/serializers/rest/search\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/scheduledstatus.md
+++ b/content/en/entities/scheduledstatus.md
@@ -96,7 +96,7 @@ This page is currently under construction.
 
 {{< page-ref page="methods/statuses/scheduled_statuses.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/scheduled_status_serializer.rb" caption="app/serializers/rest/scheduled\_status\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/scheduled_status_serializer.rb" caption="app/serializers/rest/scheduled\_status\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/status.md
+++ b/content/en/entities/status.md
@@ -285,7 +285,7 @@ menu:
 
 {{< page-ref page="methods/statuses.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/status_serializer.rb" caption="app/serializers/rest/status\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/status_serializer.rb" caption="app/serializers/rest/status\_serializer.rb" >}}
 
 
 

--- a/content/en/entities/tag.md
+++ b/content/en/entities/tag.md
@@ -83,7 +83,7 @@ menu:
 
 {{< page-ref page="methods/search.md" >}}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/tag_serializer.rb" caption="app/serializers/rest/tag\_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/tag_serializer.rb" caption="app/serializers/rest/tag\_serializer.rb" >}}
 
 
 

--- a/content/en/spec/activitypub.md
+++ b/content/en/spec/activitypub.md
@@ -13,7 +13,7 @@ Sample payloads will be added at a future date.
 
 ## Status federation {#status}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/lib/activitypub/activity.rb" caption="app/lib/activitypub/activity.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/lib/activitypub/activity.rb" caption="app/lib/activitypub/activity.rb" >}}
 
 ### Supported activities for statuses
 
@@ -75,7 +75,7 @@ Some other Object types are converted as best as possible. The transformer uses 
 
 ## HTML sanitization {#sanitization}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/lib/sanitize_config.rb" caption="app/lib/sanitize\_config.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/lib/sanitize_config.rb" caption="app/lib/sanitize\_config.rb" >}}
 
  Mastodon sanitizes incoming HTML in order to not break assumptions for API client developers. Supported elements include `<p>`, `<span>`, `<br>`, and `<a>`. Unsupported elements will be converted to `<p>`.The sanitizer will keep classes if they begin with microformats prefixes or are semantic classes:
 
@@ -91,7 +91,7 @@ Some other Object types are converted as best as possible. The transformer uses 
 
 ## JSON-LD Namespacing {#namespaces}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/lib/activitypub/adapter.rb" caption="app/lib/activitypub/adapter.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/lib/activitypub/adapter.rb" caption="app/lib/activitypub/adapter.rb" >}}
 
 ### Mastodon extensions \(`toot:`\) {#toot}
 

--- a/content/en/spec/oauth.md
+++ b/content/en/spec/oauth.md
@@ -23,7 +23,7 @@ To obtain an OAuth token for a Mastodon website, make sure that you allow your u
 
 The following descriptions are taken from the [Doorkeeper documentation](https://github.com/doorkeeper-gem/doorkeeper/wiki/API-endpoint-descriptions-and-examples). Mastodon uses Doorkeeper to implement OAuth 2. For more information on how to use these endpoints, see the [API documentation for OAuth.]({{< relref "../methods/apps/oauth.md" >}})
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/config/initializers/doorkeeper.rb" caption="Doorkeeper config initializer" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/config/initializers/doorkeeper.rb" caption="Doorkeeper config initializer" >}}
 
 ### [GET /oauth/authorize]({{< relref "../methods/apps/oauth.md#authorize-a-user" >}})
 

--- a/content/en/spec/security.md
+++ b/content/en/spec/security.md
@@ -9,7 +9,7 @@ menu:
 
 ## HTTP Signatures {#http}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/lib/request.rb" caption="app/lib/request.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/lib/request.rb" caption="app/lib/request.rb" >}}
 
 [HTTP Signatures](https://w3c-dvcg.github.io/http-signatures/) is a specification for signing HTTP messages by using a \`Signature:\` header with your HTTP request. Mastodon requires the use of HTTP Signatures in order to validate that any activity received was authored by the actor generating it. When secure mode is enabled, all GET requests require HTTP signatures as well.
 
@@ -75,7 +75,7 @@ This request is functionally equivalent to saying that `https://my-example.com/a
 
 ### Verifying HTTP signatures {#http-verify}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/controllers/concerns/signature_verification.rb" caption="app/controllers/concerns/signature\_verification.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/controllers/concerns/signature_verification.rb" caption="app/controllers/concerns/signature\_verification.rb" >}}
 
 Consider the following request:
 
@@ -97,7 +97,7 @@ Mastodon verifies the signature using the following algorithm:
 
 ## Linked Data Signatures {#ld}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/lib/activitypub/linked_data_signature.rb" caption="app/lib/activitypub/linked\_data\_signature.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/lib/activitypub/linked_data_signature.rb" caption="app/lib/activitypub/linked\_data\_signature.rb" >}}
 
 [Linked Data Signatures 1.0](https://w3c-dvcg.github.io/ld-signatures/) is a specification for attaching cryptographic signatures to JSON-LD documents. LD Signatures are not used widely within Mastodon, but they are used in the following situations:
 

--- a/content/zh-cn/admin/install.md
+++ b/content/zh-cn/admin/install.md
@@ -129,7 +129,7 @@ su - mastodon
 使用git下载最新稳定版Mastodon：
 
 ```bash
-git clone https://github.com/tootsuite/mastodon.git live && cd live
+git clone https://github.com/mastodon/mastodon.git live && cd live
 git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)
 ```
 

--- a/content/zh-cn/admin/tootctl.md
+++ b/content/zh-cn/admin/tootctl.md
@@ -23,7 +23,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 基础命令
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/cli.rb" caption="lib/cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/cli.rb" caption="lib/cli.rb" >}}
 
 ### `tootctl self-destruct` {#self-destruct}
 
@@ -51,7 +51,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 帐户相关命令 {#accounts}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/accounts_cli.rb" caption="lib/mastodon/accounts\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/accounts_cli.rb" caption="lib/mastodon/accounts\_cli.rb" >}}
 
 ### `tootctl accounts rotate` {#accounts-rotate}
 
@@ -208,7 +208,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 缓存相关命令 {#cache}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/cache_cli.rb" caption="lib/mastodon/cache\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/cache_cli.rb" caption="lib/mastodon/cache\_cli.rb" >}}
 
 ### `tootctl cache clear` {#cache-clear}
 
@@ -232,7 +232,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 域名相关命令 {#domains}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/domains_cli.rb" caption="lib/mastodon/domains\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/domains_cli.rb" caption="lib/mastodon/domains\_cli.rb" >}}
 
 ### `tootctl domains purge` {#domains-purge}
 
@@ -269,7 +269,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## Emoji相关命令 {#emoji}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/emoji_cli.rb" caption="lib/mastodon/emoji\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/emoji_cli.rb" caption="lib/mastodon/emoji\_cli.rb" >}}
 
 ### `tootctl emoji import` {#emoji-import}
 
@@ -301,7 +301,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 时间流（Feeds）相关命令 {#feeds}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/feeds_cli.rb" caption="lib/mastodon/feeds\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/feeds_cli.rb" caption="lib/mastodon/feeds\_cli.rb" >}}
 
 ### `tootctl feeds build` {#feeds-build}
 
@@ -327,7 +327,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 媒体相关命令 {#media}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/media_cli.rb" caption="lib/mastodon/media\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/media_cli.rb" caption="lib/mastodon/media\_cli.rb" >}}
 
 ### `tootctl media remove` {#media-remove}
 
@@ -390,7 +390,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 预览卡片（Preview Cards）相关命令 {#preview_cards}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/preview_cards_cli.rb" caption="lib/mastodon/preview\_cards\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/preview_cards_cli.rb" caption="lib/mastodon/preview\_cards\_cli.rb" >}}
 
 ### `tootctl preview_cards remove` {#preview_cards-remove}
 
@@ -409,7 +409,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 搜索相关命令 {#search}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/search_cli.rb" caption="lib/mastodon/search\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/search_cli.rb" caption="lib/mastodon/search\_cli.rb" >}}
 
 ### `tootctl search deploy` {#search-deploy}
 
@@ -425,7 +425,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 站点设定相关命令 {#settings}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/settings_cli.rb" caption="lib/mastodon/settings\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/settings_cli.rb" caption="lib/mastodon/settings\_cli.rb" >}}
 
 ### `tootctl settings registrations open` {#settings-registrations-open}
 
@@ -443,7 +443,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 嘟文相关命令 {#statuses}
 
-{{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/statuses_cli.rb" caption="lib/mastodon/statuses\_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/statuses_cli.rb" caption="lib/mastodon/statuses\_cli.rb" >}}
 
 ### `tootctl statuses remove` {#statuses-remove}
 

--- a/content/zh-cn/admin/upgrading.md
+++ b/content/zh-cn/admin/upgrading.md
@@ -7,10 +7,10 @@ menu:
 ---
 
 {{< hint style="info" >}}
-当一个新的Mastodon版本释出后，它将出现在[GitHub releases页面](https://github.com/tootsuite/mastodon/releases)。请注意：运行来自`master`分支的未释出代码，虽然可以进行，但不推荐这样做。
+当一个新的Mastodon版本释出后，它将出现在[GitHub releases页面](https://github.com/mastodon/mastodon/releases)。请注意：运行来自`master`分支的未释出代码，虽然可以进行，但不推荐这样做。
 {{< /hint >}}
 
-Mastodon版本与git tags一致。在尝试升级之前，请至[GitHub releases页面](https://github.com/tootsuite/mastodon/releases)查找所需版本。该页面包含了一个**更新日专**，其中描述你需要了解的所有差异，以及**特定的升级指令**。
+Mastodon版本与git tags一致。在尝试升级之前，请至[GitHub releases页面](https://github.com/mastodon/mastodon/releases)查找所需版本。该页面包含了一个**更新日专**，其中描述你需要了解的所有差异，以及**特定的升级指令**。
 
 开始之前，切换至`mastodon`用户：
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,7 +11,7 @@
     {{ .Content }}
 
     <p style="color: #687590;">
-      {{ i18n "lastUpdated" }} {{ .Lastmod.Format "January 2, 2006" }}{{ with .File }} · <a href='https://github.com/tootsuite/documentation/tree/master/content/{{ .Lang }}/{{ .Path }}' style="color: #687590;">{{ i18n "improvePage" }}{{ end }}</a>
+      {{ i18n "lastUpdated" }} {{ .Lastmod.Format "January 2, 2006" }}{{ with .File }} · <a href='https://github.com/mastodon/documentation/tree/master/content/{{ .Lang }}/{{ .Path }}' style="color: #687590;">{{ i18n "improvePage" }}{{ end }}</a>
 
       {{ if .IsTranslated }}
         <br />

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,7 +11,7 @@
     {{ .Content }}
 
     <p style="color: #687590;">
-      {{ i18n "lastUpdated" }} {{ i18n "lastUpdatedDateFormat"  .Lastmod }}{{ with .File }} · <a href='https://github.com/tootsuite/documentation/tree/master/content/{{ .Lang }}/{{ .Path }}' style="color: #687590;">{{ i18n "improvePage" }}{{ end }}</a>
+      {{ i18n "lastUpdated" }} {{ i18n "lastUpdatedDateFormat"  .Lastmod }}{{ with .File }} · <a href='https://github.com/mastodon/documentation/tree/master/content/{{ .Lang }}/{{ .Path }}' style="color: #687590;">{{ i18n "improvePage" }}{{ end }}</a>
 
       {{ if .IsTranslated }}
         <br />

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -18,10 +18,10 @@
       </div>
     </div>
   </div>
-  
+
   <p class="legal legal--right">
     <a href='https://joinmastodon.org'>{{ i18n "joinMastodon" }}</a> · <a href='https://blog.joinmastodon.org'>{{ i18n "blog" }}</a> · <a href='https://mastodon.social/@Mastodon' target='_blank'><i class='fab fa-mastodon'></i></a> · <a href='https://twitter.com/joinmastodon' rel='nofollow' target='_blank'><i class='fab fa-twitter'></i></a>
   </p>
 
-  <p class="legal">{{ with .File }}<a href='https://github.com/tootsuite/documentation/tree/master/content/{{ .Lang }}/{{ .File.Path }}'>{{ i18n "viewSource" }}</a> · {{ end }}<a href='https://creativecommons.org/licenses/by-sa/4.0/'>CC BY-SA 4.0</a> · <a href='https://joinmastodon.org/imprint'>{{ i18n "imprint" }}</a></p>
+  <p class="legal">{{ with .File }}<a href='https://github.com/mastodon/documentation/tree/master/content/{{ .Lang }}/{{ .File.Path }}'>{{ i18n "viewSource" }}</a> · {{ end }}<a href='https://creativecommons.org/licenses/by-sa/4.0/'>CC BY-SA 4.0</a> · <a href='https://joinmastodon.org/imprint'>{{ i18n "imprint" }}</a></p>
 </footer>

--- a/layouts/shortcodes/translation-status-zh-cn.html
+++ b/layouts/shortcodes/translation-status-zh-cn.html
@@ -1,6 +1,6 @@
 <figure>
     <p>
         <strong>翻译状态：</strong>
-        本文是英文页面 <a href="{{ .Get "raw_link" }}">{{ .Get "raw_title" }}</a> 的翻译，最后翻译时间：{{ .Get "last_tranlation_time" }}，点击<a href="https://github.com/tootsuite/documentation/compare/{{ .Get "raw_commit" }}...master">这里</a>可以查看翻译后页面的改动。
+        本文是英文页面 <a href="{{ .Get "raw_link" }}">{{ .Get "raw_title" }}</a> 的翻译，最后翻译时间：{{ .Get "last_tranlation_time" }}，点击<a href="https://github.com/mastodon/documentation/compare/{{ .Get "raw_commit" }}...master">这里</a>可以查看翻译后页面的改动。
     </p>
 </figure>


### PR DESCRIPTION
Ran `grep` over the codebase to identify remaining links to old repo address.

Note: some extra changes because my editor is configure to kill trailing whitespace.