### PR TITLE
Document that S3 ACLs must be enabled

### DIFF
--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -554,6 +554,8 @@ You must serve the files with CORS headers, otherwise some functions of Mastodon
 
 {{< page-ref page="admin/optional/object-storage" >}}
 
+The bucket must support access control lists (ACLs). For AWS S3, this means setting the "Object Ownership" setting to "ACLs enabled". For Google Cloud Storage, this means setting the "Access control" setting to "Fine-grained".
+
 #### `S3_ENABLED`
 
 #### `S3_REGION`


### PR DESCRIPTION
When using S3 compatible object stores to save attachments, object-level ACLs must be enabled. If they are not enabled, attaching pictures to toots will fail. For some object stores, the error message does not indicate the root cause of the problem.

Unfortunately it is likely that people will accidentally disable ACLs when first setting up Mastodon. This is because both AWS S3 and Google cloud storage disable object-level ACLs by default. The GUIs for creating buckets recommend somewhat strongly that they should not be enabled.

For example, [the AWS docs say](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html)

> we recommend that you disable ACLs except in unusual circumstances

And the creation UI looks like this:

![image](https://user-images.githubusercontent.com/7751/204085248-b5f61da3-cb9c-4dfe-8de8-78e1971b7703.png)

It appears I'm not the only person who has had trouble with this:

* mastodon/mastodon#17435
* mastodon/mastodon#17978
