### PR TITLE
Clarify axis info on media "focus" parameter

### DIFF
--- a/content/en/methods/statuses/media.md
+++ b/content/en/methods/statuses/media.md
@@ -41,7 +41,7 @@ The custom thumbnail of the media to be attached, using multipart form data.
 A plain-text description of the media, for accessibility purposes.
 {{< endapi-method-parameter >}}
 {{< api-method-parameter name="focus" type="string" required=false >}}
-Two floating points \(x,y\), comma-delimited, ranging from -1.0 to 1.0
+Two floating points \(x,y\), comma-delimited, ranging from -1.0 to 1.0 (see "Focal points" below)
 {{< endapi-method-parameter >}}
 {{< endapi-method-form-data-parameters >}}
 {{< endapi-method-request >}}


### PR DESCRIPTION
Today I read the media/ api endpoint document and was confused about the axis orientation (IE is y up or down). I initially implemented an endpoint call with the wrong Y orientation.

There is a helpful diagram but I did not see it because I foolishly scrolled down, saw the return codes section, assumed that was the end of the document, and didn't scroll further.

Edit adds a reference from the arguments section at the top to the detailed explanation of "focus" at the bottom of the page, so the next fool doesn't make the mistake I did.