### PR TITLE
Added text after a colon in install.md (there was none)

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -13,7 +13,7 @@ menu:
 * A **domain name** \(or a subdomain\) for the Mastodon server, e.g. `example.com`
 * An e-mail delivery service or other **SMTP server**
 
-You will be running the commands as root. If you aren’t already root, switch to root:
+You will be running the commands as root. If you aren’t already root, switch to root: `sudo su -`
 
 ### System repositories {#system-repositories}
 


### PR DESCRIPTION
I'm guessing there was meant to be text there, so I added some to explain how to do it