### PR TITLE
tootctl > Adjusts role name examples to title case

### DIFF
--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -76,7 +76,7 @@ Create a new user account with given USERNAME and provided --email.
 | `USERNAME`             | Local username for the new account. Required. |
 | `--email EMAIL`        | Email address to be attached to the user. Required. |
 | `--confirmed`          | Skip sending the confirmation email and activate the account immediately. |
-| `--role ROLE`          | Define the new account as a `user`, `moderator`, or `admin`. Defaults to `user`. |
+| `--role ROLE`          | Define the new account as a `User`, `Moderator`, or `Admin`. Defaults to `User`. |
 | `--reattach`           | Reuse an old USERNAME after its account has been deleted. |
 | `--force`              | Forcefully delete any existing account with this USERNAME and reattach the new account in place of the \(just-deleted\) account. |
 | `--skip-sign-in-token` | Forcefully ensure that the user is never asked for an e-mailed security code. |


### PR DESCRIPTION
The examples in the table will not work with the current version of `tootctl`.

Fixes https://github.com/mastodon/mastodon/issues/18813