### PR TITLE
Fixes Fail2Ban's directive

### DIFF
--- a/content/en/admin/prerequisites.md
+++ b/content/en/admin/prerequisites.md
@@ -45,6 +45,7 @@ port = 22
 
 [sshd-ddos]
 enabled = true
+filter = sshd
 port = 22
 ```
 


### PR DESCRIPTION
Without `filter = sshd` and after restarting the service I see this error in Fail2Ban's logs (`/var/log/fail2ban.log`):

```
2022-11-03 11:24:36,225 fail2ban.transmitter    [1283507]: ERROR   Jail 'sshd-ddos' skipped, because of wrong configuration: Unable to read the filter 'sshd-ddos'
```

I added the statement as per [this article](https://serverfault.com/a/1050315) and it worked.