### PR TITLE
Bump Hugo from `0.62.1` to `0.105.0`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v2
       with:
-        hugo-version: '0.62.1'
+        hugo-version: '0.105.0'
         extended: true
 
     - name: Build


### PR DESCRIPTION
Fixes #967

# Notes

This Hugo upgrade causes significant changes to the static output. Manually browsing the site, I have not found any issues.

## `diff 0.62.1 0.105.0`

Static output: https://github.com/siggy/documentation/commit/f5b131652a7d6ec4c669e42683c11cf9567cfe57

Live sites:
- https://docs.joinmastodon.org
- https://documentation.sig.gy

## Fix #967

- https://docs.joinmastodon.org/client/libraries/
- https://documentation.sig.gy/client/libraries/

## Differences

This is a non-exhaustive list of differences.

### Static output shows an additional sentence in `docs/admin/index.xml`

https://github.com/siggy/documentation/commit/f5b131652a7d6ec4c669e42683c11cf9567cfe57#diff-4ab173a3f7265427b820697115f923b70b04bb1a13abb290546df951b0f4d050R121

The live pages are identical:
- https://docs.joinmastodon.org/admin/optional/object-storage-proxy/
- https://documentation.sig.gy/admin/optional/object-storage-proxy/

### Some `id` attributes changed from dashes to underscores

#### `local-domain` => `local_domain`
https://github.com/siggy/documentation/commit/f5b131652a7d6ec4c669e42683c11cf9567cfe57#diff-0d77b0878a0a852233a9f2093973738aedd5e9b2b1ab49e22f9c645afe52d569R846

- https://docs.joinmastodon.org/admin/config/#local-domain
- https://documentation.sig.gy/admin/config/#local_domain

#### `optionsvotes-count` => `optionsvotes_count`
https://github.com/siggy/documentation/commit/f5b131652a7d6ec4c669e42683c11cf9567cfe57#diff-701ab3c19b8af8b039953ee9e4aa148dbf2f8b882d21cbccfb1c14472cc5351cR900

- https://docs.joinmastodon.org/entities/poll/#optionsvotes-count
- https://documentation.sig.gy/entities/poll/#optionsvotes_count

## Repro

To reproduce the issue described in #967 (and diff current and upgraded):

```bash
docker run -it ruby:3.1.2-slim-bullseye /bin/bash
```

In the container:

```bash
apt-get update && apt-get install -y curl gcc git make

before=$(mktemp -d)
(
  cd $before
  curl -sLO https://github.com/gohugoio/hugo/releases/download/v0.62.1/hugo_extended_0.62.1_Linux-64bit.tar.gz
  tar xvfz hugo_extended_0.62.1_Linux-64bit.tar.gz
)

after=$(mktemp -d)
(
  cd $after
  curl -sLO https://github.com/gohugoio/hugo/releases/download/v0.105.0/hugo_extended_0.105.0_linux-amd64.tar.gz
  tar xvfz hugo_extended_0.105.0_linux-amd64.tar.gz
)

git clone https://github.com/mastodon/documentation.git
(
  cd documentation
  $before/hugo --destination $before/site
  $after/hugo --destination $after/site
)

diff -r --color $before/site $after/site
```
