### PR TITLE
Add Cloudplane to hosting providers

### DIFF
--- a/content/en/user/run-your-own.md
+++ b/content/en/user/run-your-own.md
@@ -48,6 +48,8 @@ There exist a number of **dedicated Mastodon hosting providers** that take care 
 
 {{< caption-link url="https://fedi.monster/" caption="Fedi.monster >}}
 
+{{< caption-link url="https://cloudplane.org" caption="Cloudplane" >}}
+
 Managed hosting solutions are great for those who do not have experience or desire to install and maintain software. However, being in charge of all components on your own hardware gives greater control over scaling, performance and customization.
 
 We provide a **DigitalOcean 1-Click Install Image** that you can put on a DigitalOcean droplet of your choosing which essentially gives you everything you would otherwise have after following our installation instructions through an interactive setup wizard.


### PR DESCRIPTION
Service is owned and operated by me. I joined Mastodon recently and noticed that many providers are struggling to keep up with the demand, so I added support for Mastodon to our managed hosting platform.

https://cloudplane.org/