### PR TITLE
Update install.md to use yarn version classic

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -53,7 +53,7 @@ apt install -y \
 
 ```bash
 corepack enable
-yarn set version stable
+yarn set version classic
 ```
 
 ### Installing Ruby {#installing-ruby}


### PR DESCRIPTION
`yarn set version stable` yields many install errors of Javascript packages.  note https://codesti.com/issue/mastodon/documentation/931.

Setting `yarn set version classic` works around these problems and the rest of the instructions work as indicated.  `classic` appears to be required.