### PR TITLE
Update firewall examples to fix PMTUD issues

### DIFF
--- a/content/en/admin/prerequisites.md
+++ b/content/en/admin/prerequisites.md
@@ -88,6 +88,9 @@ Edit `/etc/iptables/rules.v4` and put this inside:
 #  Allow ping
 -A INPUT -p icmp -m icmp --icmp-type 8 -j ACCEPT
 
+# Allow destination unreachable messages, espacally code 4 (fragmentation required) is required or PMTUD breaks
+-A INPUT -p icmp -m icmp --icmp-type 3 -j ACCEPT
+
 #  Log iptables denied calls
 -A INPUT -m limit --limit 5/min -j LOG --log-prefix "iptables denied: " --log-level 7
 


### PR DESCRIPTION
Current firewall examples block ICMP messages, which are required for IPv4 PMTUD. This breaks some IPv4 connections that rely on working PMTUD between client and server.

This fixes #999.