### PR TITLE
Fix Nginx related permission

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -183,6 +183,14 @@ exit
 
 ### Setting up nginx {#setting-up-nginx}
 
+
+Nginx needs permission to traverse `/home/mastodon`:
+
+```bash
+sudo chmod o+x ~
+```
+
+
 Copy the configuration template for nginx from the Mastodon directory:
 
 ```bash


### PR DESCRIPTION
Without this permission, when installing a fresh instance on Ubuntu 22.10, I'm unable to load any assets and the nginx error log goes like this:

```
2022/11/11 20:40:20 [crit] 1552814#1552814: *1 stat() "/home/mastodon2/live/public/" failed (13: Permission denied), client: 2a02:a44b:5cf9:1:6d61:dcd8:5606:9390, server: mastodon.sprovoost.nl, request: "GET / HTTP/2.0", host: "mastodon.sprovoost.nl"
```

That said, a more narrow permission would be nicer.