### PR TITLE
Add iptables-configuration for IPv6

### DIFF
--- a/content/en/admin/prerequisites.md
+++ b/content/en/admin/prerequisites.md
@@ -104,3 +104,41 @@ With iptables-persistent, that configuration will be loaded at boot time. But si
 iptables-restore < /etc/iptables/rules.v4
 ```
 
+If your server is also reachable over IPv6, edit `/etc/iptables/rules.v6` and add this inside:
+```text
+*filter
+
+#  Allow all loopback (lo0) traffic and drop all traffic to 127/8 that doesn't use lo0
+-A INPUT -i lo -j ACCEPT
+-A INPUT ! -i lo -d ::1/128 -j REJECT
+
+#  Accept all established inbound connections
+-A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+#  Allow all outbound traffic - you can modify this to only allow certain traffic
+-A OUTPUT -j ACCEPT
+
+#  Allow HTTP and HTTPS connections from anywhere (the normal ports for websites and SSL).
+-A INPUT -p tcp --dport 80 -j ACCEPT
+-A INPUT -p tcp --dport 443 -j ACCEPT
+
+#  Allow SSH connections
+#  The -dport number should be the same port number you set in sshd_config
+-A INPUT -p tcp -m state --state NEW --dport 22 -j ACCEPT
+
+#  Allow ping
+-A INPUT -p icmpv6 -j ACCEPT
+
+#  Log iptables denied calls
+-A INPUT -m limit --limit 5/min -j LOG --log-prefix "iptables denied: " --log-level 7
+
+#  Reject all other inbound - default deny unless explicitly allowed policy
+-A INPUT -j REJECT
+-A FORWARD -j REJECT
+
+COMMIT
+```
+Simmilar to the IPv4 rules, you can load it manually like this:
+```bash
+ip6tables-restore < /etc/iptables/rules.v6
+```


### PR DESCRIPTION
The configuration is basically the same as with IPv4, but with some minor changes to make them work in IPv6.

Is it perfect? Probably not. But it's better than nothing.