### PR TITLE
Update to use definitive Mastodon repository

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -140,7 +140,7 @@ su - mastodon
 Use git to download the latest stable release of Mastodon:
 
 ```bash
-git clone https://github.com/tootsuite/mastodon.git live && cd live
+git clone https://github.com/mastodon/mastodon.git live && cd live
 git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)
 ```
 


### PR DESCRIPTION
https://github.com/tootsuite/mastodon.git is no longer the definitive repository, use https://github.com/mastodon/mastodon.git

Resolves https://github.com/mastodon/documentation/issues/1010