### PR TITLE
Add links to sub-pages for optional stuff

### DIFF
--- a/content/en/admin/optional.md
+++ b/content/en/admin/optional.md
@@ -7,3 +7,8 @@ menu:
     identifier: admin-optional
 ---
 
+Mastodon offers a few optional features that can be used if needed.
+
+- [Full-text search](./elasticsearch/)
+- [Hidden services](./tor/)
+- [Single Sign On](./sso/)


### PR DESCRIPTION
Adds links to `/admin/optional/` to not have the page be this empty.