### PR TITLE
Updated to support Mastodon 4.x

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -84,8 +84,8 @@ git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 Once this is done, we can install the correct Ruby version:
 
 ```bash
-RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install 3.0.3
-rbenv global 3.0.3
+RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install 3.0.4
+rbenv global 3.0.4
 ```
 
 We’ll also need to install bundler:


### PR DESCRIPTION
When you run:
$ bundle config without 'development test'
You get:
rbenv: version `3.0.4' is not installed (set by /home/mastodon/live/.ruby-version)