### PR TITLE
Latest mastodon requires Ruby 3.0.4

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -84,8 +84,9 @@ git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 Once this is done, we can install the correct Ruby version:
 
 ```bash
-RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install 3.0.3
-rbenv global 3.0.3
+# Based on: Mastodon 4.0.2
+RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install 3.0.4
+rbenv global 3.0.4
 ```
 
 We’ll also need to install bundler:


### PR DESCRIPTION
Performing fresh-install starting from DEBIAN 11 and found it requires ruby 3.0.4.
![traceback](https://user-images.githubusercontent.com/34373595/201868764-6ed527ae-8619-4a93-8c38-768852148965.png)
