### PR TITLE
Specify where to find Site Settings page

### DIFF
--- a/content/en/admin/setup.md
+++ b/content/en/admin/setup.md
@@ -33,7 +33,7 @@ A randomly generated password will be shown in the terminal.
 
 ## Filling in server information {#info}
 
-After logging in, navigate to the **Site settings** page. While there are no technical requirements for filling in this information, it is considered crucial for operating a server for humans.
+After logging in, navigate to the **Site settings** page (under **Preferences** -> **Administration**). While there are no technical requirements for filling in this information, it is considered crucial for operating a server for humans.
 
 | Setting | Meaning |
 | :--- | :--- |


### PR DESCRIPTION
New to Mastodon, not familiar with the UI, I'm a bit dense so it took me several minutes to find this page 😂 

Hope this PR can help save a few minutes to other folks out there