### PR TITLE
Uppercase the roles permitted to be supplied to --role option

### DIFF
--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -92,7 +92,7 @@ Modify a user account's role, email, active status, approval mode, or 2FA requir
 | Option | Description |
 | :--- | :--- |
 | `USERNAME` | Local username for the account. Required. |
-| `--role ROLE` | Define the account as a `user`, `moderator`, or `admin`. |
+| `--role ROLE` | Define the account as a `User`, `Moderator`, or `Admin`. |
 | `--email EMAIL` | Update the user's email address to EMAIL. |
 | `--confirm` | Skip confirmation email, when used with --email. |
 | `--disable` | Lock USERNAME out of their account. |


### PR DESCRIPTION
The lowercase versions previously employed did not result in the desired effect.