### PR TITLE
Add mobile nav toggle

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -195,9 +195,44 @@ body {
 }
 
 .sidebar {
-  @media screen and (max-width: $mobile-width) {
-    margin-bottom: 60px;
-  }
+    @media screen and (max-width: $mobile-width) {
+        margin-bottom: 60px;
+
+        input[type="checkbox"] {
+            display: none;
+        }
+        label {
+            font-size: 1.2rem;
+            display: flex;
+            justify-content: flex-end;
+            margin-bottom: 2rem;
+        }
+        label i {
+            margin-right: .25rem;
+        }
+        input[type="checkbox"]:not(:checked) + label > .menu-open {
+            display: none;
+        }
+
+        input[type="checkbox"]:checked + label > .menu-close {
+            display: none;
+        }
+
+        & > ul {
+            display: none;
+        }
+
+        #mobile-nav-toggle:checked ~ ul {
+            display: block;
+        }
+    }
+
+    @media screen and (min-width: $mobile-width) {
+        .mobile-nav-wrapper {
+            display: none;
+        }
+    }
+
 
   .brand {
     display: flex;

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -198,6 +198,11 @@ body {
     @media screen and (max-width: $mobile-width) {
         margin-bottom: 60px;
 
+        // css menu toggle for mobile.
+        // when the checkbox is checked, the menu shows,
+        // othewise it's hidden.
+        // it's important for it all to be scoped inside this media query,
+        // that way on larger screens the menu will always show even if the checkbox is unchecked.
         input[type="checkbox"] {
             display: none;
         }
@@ -227,8 +232,10 @@ body {
         }
     }
 
+    // on viewport sizes larger than mobile, always hide the mobile nav toggle.
     @media screen and (min-width: $mobile-width) {
-        .mobile-nav-wrapper {
+        .mobile-nav-toggle,
+        .mobile-nav-toggle + label {
             display: none;
         }
     }

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -2,6 +2,16 @@
   <img class="link-logo" src="{{ relURL "brand.svg" }}" alt="Mastodon" />
 </a>
 
+<input id="mobile-nav-toggle" class="mobile-nav-toggle" type="checkbox" checked>
+<label for="mobile-nav-toggle">
+    <span class="menu-open">
+        <i class="fa fa-times"></i> Close
+    </span>
+    <span class="menu-close">
+        <i class="fa fa-bars"></i> Menu
+    </span>
+</label>
+
 <ul>
   {{ $currentPage := . }}
   {{ range .Site.Menus.docs.ByWeight }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -2,7 +2,7 @@
   <img class="link-logo" src="{{ relURL "brand.svg" }}" alt="Mastodon" />
 </a>
 
-<input id="mobile-nav-toggle" class="mobile-nav-toggle" type="checkbox" checked>
+<input id="mobile-nav-toggle" class="mobile-nav-toggle" type="checkbox">
 <label for="mobile-nav-toggle">
     <span class="menu-open">
         <i class="fa fa-times"></i> Close


### PR DESCRIPTION
This adds a CSS-only nav menu toggle on mobile using a hidden checkbox input. On non-mobile viewports, the toggles are hidden and the menu always shows regardless of whether the checkbox is checked.

## Why?

The menu is super long and on mobile, you have to scroll a long way to get to content. It's not a great user experience, especially since every page you navigate to you have to scroll the menu again.

I'm not a designer, and this design is very much functional as opposed to looking the best. I'm very open to feedback if anyone wants to help out and make it look nicer.

Here's a couple screenshots:

### Closed
<img width="451" alt="image" src="https://user-images.githubusercontent.com/6248612/202863469-e09159c8-dae5-45d9-95d0-25e7ef921f00.png">

### Open
<img width="451" alt="image" src="https://user-images.githubusercontent.com/6248612/202863479-d03fc9aa-e0ea-4c46-a462-63a94740bdf7.png">
