### PR TITLE
Update install instructions

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -84,8 +84,8 @@ git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 Once this is done, we can install the correct Ruby version:
 
 ```bash
-RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install 3.0.3
-rbenv global 3.0.3
+RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install 3.0.4
+rbenv global 3.0.4
 ```
 
 We’ll also need to install bundler:
@@ -106,7 +106,7 @@ exit
 
 #### Performance configuration \(optional\) {#performance-configuration-optional}
 
-For optimal performance, you may use [pgTune](https://pgtune.leopard.in.ua/#/) to generate an appropriate configuration and edit values in `/etc/postgresql/14/main/postgresql.conf` before restarting PostgreSQL with `systemctl restart postgresql`
+For optimal performance, you may use [pgTune](https://pgtune.leopard.in.ua/#/) to generate an appropriate configuration and edit values in `/etc/postgresql/15/main/postgresql.conf` before restarting PostgreSQL with `systemctl restart postgresql`
 
 #### Creating a user {#creating-a-user}
 
@@ -193,6 +193,11 @@ ln -s /etc/nginx/sites-available/mastodon /etc/nginx/sites-enabled/mastodon
 Then edit `/etc/nginx/sites-available/mastodon` to replace `example.com` with your own domain name, and make any other adjustments you might need.
 
 Reload nginx for the changes to take effect:
+
+
+```bash
+systemctl reload nginx
+```
 
 ### Acquiring a SSL certificate {#acquiring-a-ssl-certificate}
 


### PR DESCRIPTION
I installed Mastodon 4.0.2 yesterday on Ubuntu 22.04.1 (Nov 18th) and needed to change things a bit.

1. Had to install Ruby 3.0.4 instead of 3.0.3
2. Following the instructions installed postgres 15, so the config path was different

I also had to comment the https section of the nginx config file, as nginx failed as there were no certs specified for it... but reading the doc, I'm not sure if it was due to some particularity of my system.