### PR TITLE
Add installation step to allow www-data to traverse ~mastodon

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -64,6 +64,12 @@ We will be using rbenv to manage Ruby versions, because it’s easier to get the
 adduser --disabled-login mastodon
 ```
 
+The mastodon user's home directory will contain the application, so we need to ensure that other users (such as the web server process) can traverse files in it:
+
+```bash
+chmod a+x /home/mastodon
+```
+
 We can then switch to the user:
 
 ```bash


### PR DESCRIPTION
When running the current installation steps, nginx can't access files in ~mastodon/live and gives the error (in `/var/log/nginx/error.log`) 

```
stat() "/home/mastodon/live/public/packs/js/locale_en-3ded4a5c02d2d7a36bd0.chunk.js" failed (13: Permission denied)
```

The easiest way to solve this seems to be adding the +x permission to the base home directory. 