### PR TITLE
Update object-storage-proxy.md

### DIFF
--- a/content/en/admin/optional/object-storage-proxy.md
+++ b/content/en/admin/optional/object-storage-proxy.md
@@ -37,7 +37,7 @@ server {
     }
 
     resolver 8.8.8.8;
-    proxy_set_header Host YOUR_S3_HOSTNAME;
+    proxy_set_header Host YOUR_BUCKET_NAME.YOUR_S3_HOSTNAME;
     proxy_set_header Connection '';
     proxy_set_header Authorization '';
     proxy_hide_header Set-Cookie;


### PR DESCRIPTION
This documentation has I believe one confusing point: It uses two times `YOUR_S3_HOSTNAME` in the nginx configuration example, however the second time it looks like you actually have to use `YOUR_BUCKET_NAME.YOUR_S3_HOSTNAME`.

## Explanation
Mastodon seems to be using path-style requests to S3 which looks like this:
https://s3.region-code.amazonaws.com/bucket-name/key-name

Once you enable the S3_ALIAS_HOST in .env.production and the new nginx vhost file described in this documentation, the path-style request which goes to amazon looks like this:
https://s3.region-code.amazonaws.com/key-name

In other words, **the bucket name is not being sent to S3** and the images break.

Because of this this precedent in the file: `set $s3_backend 'https://YOUR_BUCKET_NAME.YOUR_S3_HOSTNAME';`, the current instructions make it seem like the header Host value should not include the bucket:
`proxy_set_header Host YOUR_S3_HOSTNAME;`


However it seems that for this to work with the current path-style request integration, one must use the bucket name in the Host header value for this to work, hence the proposed change to:

`proxy_set_header Host YOUR_BUCKET_NAME.YOUR_S3_HOSTNAME;`