### PR TITLE
Update oauth.md to include `client_secret` form parameter

### DIFF
--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -100,6 +100,9 @@ code
 
 client_id
 : {{<required>}} String. The client ID, obtained during app registration.
+  
+client_secret
+: {{<required>}} String. The client secret, obtained during app registration.
 
 redirect_uri
 : {{<required>}} String. Set a URI to redirect the user to. If this parameter is set to urn:ietf:wg:oauth:2.0:oob then the token will be shown instead. Must match one of the `redirect_uris` declared during app registration.


### PR DESCRIPTION
When testing the OAuth flow, I was only able to proceed by adding the `client_secret` as a form parameter when requesting a token. 