### PR TITLE
Fix outdated internal cross-reference

### DIFF
--- a/content/en/methods/media.md
+++ b/content/en/methods/media.md
@@ -1,7 +1,7 @@
 ---
 title: media API methods
 description: >-
-  Attach media to authored statuses. See Using Mastodon > Posting toots >
+  Attach media to authored statuses. See Using Mastodon > Posting to your profile >
   Attachments for more information about size and format limits.
 menu:
   docs:


### PR DESCRIPTION
The title of the referenced section has changed in 3628b6d43413369069690d88ab7455fc82793d8f