### PR TITLE
Disambiguate hostnames

### DIFF
--- a/content/en/admin/optional/object-storage-proxy.md
+++ b/content/en/admin/optional/object-storage-proxy.md
@@ -37,7 +37,7 @@ server {
     }
 
     resolver 8.8.8.8;
-    proxy_set_header Host YOUR_S3_HOSTNAME;
+    proxy_set_header Host YOUR_BUCKET_NAME.YOUR_S3_HOSTNAME;
     proxy_set_header Connection '';
     proxy_set_header Authorization '';
     proxy_hide_header Set-Cookie;


### PR DESCRIPTION
One line says bucket & hostname, the next just hostname when in fact them both need to by bucket & hostname.