### PR TITLE
Replace broken link to HTTP Signatures

### DIFF
--- a/content/en/spec/security.md
+++ b/content/en/spec/security.md
@@ -11,7 +11,7 @@ menu:
 
 {{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/lib/request.rb" caption="app/lib/request.rb" >}}
 
-[HTTP Signatures](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures-15) is a specification for signing HTTP messages by using a \`Signature:\` header with your HTTP request. Mastodon requires the use of HTTP Signatures in order to validate that any activity received was authored by the actor generating it. When secure mode is enabled, all GET requests require HTTP signatures as well.
+[HTTP Signatures](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12) is a specification for signing HTTP messages by using a \`Signature:\` header with your HTTP request. Mastodon requires the use of HTTP Signatures in order to validate that any activity received was authored by the actor generating it. When secure mode is enabled, all GET requests require HTTP signatures as well.
 
 For any HTTP request incoming to Mastodon, the following header should be attached:
 

--- a/content/en/spec/security.md
+++ b/content/en/spec/security.md
@@ -11,7 +11,7 @@ menu:
 
 {{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/lib/request.rb" caption="app/lib/request.rb" >}}
 
-[HTTP Signatures](https://w3c-dvcg.github.io/http-signatures/) is a specification for signing HTTP messages by using a \`Signature:\` header with your HTTP request. Mastodon requires the use of HTTP Signatures in order to validate that any activity received was authored by the actor generating it. When secure mode is enabled, all GET requests require HTTP signatures as well.
+[HTTP Signatures](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures-15) is a specification for signing HTTP messages by using a \`Signature:\` header with your HTTP request. Mastodon requires the use of HTTP Signatures in order to validate that any activity received was authored by the actor generating it. When secure mode is enabled, all GET requests require HTTP signatures as well.
 
 For any HTTP request incoming to Mastodon, the following header should be attached:
 


### PR DESCRIPTION
Replace broken link to HTTP Signatures in security.md. The previous link instructed to redirect to an outdated audit. The new link leads to the current IETF draft for HTTP Signatures.