### PR TITLE
Add link to Action Mailer documentation

### DIFF
--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -408,6 +408,8 @@ Set to `auto` (default), `always`, or `never`.
 #### `SMTP_TLS`
 #### `SMTP_SSL`
 
+The SMTP configuration options listed above have the meaning described in [the Action Mailer documentation](https://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration).
+
 ## File storage {#files}
 
 ### CDN {cdn}


### PR DESCRIPTION
The "Configuring your environment" section lists some options related to configuring an SMTP server for Mastodon.

However, the meaning of these options is not self-explanatory for a common Mastodon user. In fact, I had to browse the Mastodon source code to find that these options are simply forwarded to the Ruby On Rails Action Mailer.

With this pull request, I add a link to the Action Mailer configuration options, so that Mastodon users can better understand the meaning of the SMTP server configuration options.