### PR TITLE
Update prerequisites.md

### DIFF
--- a/content/en/admin/prerequisites.md
+++ b/content/en/admin/prerequisites.md
@@ -46,6 +46,7 @@ port = 22
 [sshd-ddos]
 enabled = true
 port = 22
+filter = sshd
 ```
 
 Finally restart fail2ban:


### PR DESCRIPTION
Section [sshd-ddos] requires the filter to be set to sshd - else it will result in an error complaining that it could not find the filter "sshd-ddos".