### PR TITLE
Update config.md: CORS header in redirect example

### DIFF
--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -29,6 +29,7 @@ To install Mastodon on `mastodon.example.com` in such a way it can serve `@alice
 
 ```
 location /.well-known/webfinger {
+  add_header Access-Control-Allow-Origin '*';
   return 301 https://mastodon.example.com$request_uri;
 }
 ```


### PR DESCRIPTION
Per RFC 7033, section 5,  "[WebFinger] servers MUST include the Access-Control-Allow-Origin HTTP header in responses.  Servers SHOULD support the least restrictive setting by allowing any domain access to the WebFinger resource: Access-Control-Allow-Origin: *"

It appears that many Mastodon instances with LOCAL_DOMAIN != WEB_DOMAIN can currently not be webfinger'ed from a browser using the LOCAL_DOMAIN due to this missing header. Adding it to the nginx configuration example should help to limit that issue for future installations.