### PR TITLE
Added info about CMS limitation and link highlight

### DIFF
--- a/content/en/user/profile.md
+++ b/content/en/user/profile.md
@@ -86,4 +86,4 @@ More precisely, Mastodon will validate the link under the following conditions:
 
 Alternatively, validation will occur if the resolved page's *first* link has an `href` value that redirects to your Mastodon profile's URL (such as through a link shortener).
 
-If validation succeeds, the link to your website will turn green on your profile page. This may take a few minutes even after you deploy the update to your site's HTML. 
+If validation succeeds, the link to your website will turn green on your profile page. This may take a few minutes even after you deploy the update to your site's HTML. Should validation fail: remove the link from your Mastodon profile; correct the link in your website's HTML and redeploy; re-add the link to your Mastodon profile. 

--- a/content/en/user/profile.md
+++ b/content/en/user/profile.md
@@ -84,6 +84,6 @@ More precisely, Mastodon will validate the link under the following conditions:
 - the resolved page contains at least one `a` or `link` tag with a `rel="me"`
 - the `href` attribute on one of those elements is equal to the URL for your Mastodon profile
 
-Alternately, validation will occur if the resolved page's *first* link has an `href` value that redirects to your Mastodon profile's URL (such as through a link shortener).
+Alternatively, validation will occur if the resolved page's *first* link has an `href` value that redirects to your Mastodon profile's URL (such as through a link shortener).
 
 If validation succeeds, the link to your website will turn green on your profile page. This may take a few minutes even after you deploy the update to your site's HTML. 

--- a/content/en/user/profile.md
+++ b/content/en/user/profile.md
@@ -79,7 +79,7 @@ If you put an HTTPS link in your profile metadata, Mastodon checks if that link 
 
 More precisely, Mastodon will validate the link under the following conditions:
 - Since 4.0: the hostname does not change after IDN normalization
-- the link to your Mastodon profile is added to a static HTML page used in your site. Websites served via Javascript-heavy content management systems such as StoryBlok often do not include static HTML, but check with your site developer
+- the link to your Mastodon profile is added to a static HTML page used in your site. Websites served via Javascript-heavy content management systems may not support these links. Check with your site developer.
 - it starts with HTTPS
 - the resolved page contains at least one `a` or `link` tag with a `rel="me"`
 - the `href` attribute on one of those elements is equal to the URL for your Mastodon profile

--- a/content/en/user/profile.md
+++ b/content/en/user/profile.md
@@ -79,8 +79,11 @@ If you put an HTTPS link in your profile metadata, Mastodon checks if that link 
 
 More precisely, Mastodon will validate the link under the following conditions:
 - Since 4.0: the hostname does not change after IDN normalization
+- the link to your Mastodon profile is added to a static HTML page used in your site. Websites served via Javascript-heavy content management systems such as StoryBlok often do not include static HTML, but check with your site developer
 - it starts with HTTPS
 - the resolved page contains at least one `a` or `link` tag with a `rel="me"`
 - the `href` attribute on one of those elements is equal to the URL for your Mastodon profile
 
-Alternatively, validation will occur if the resolved page's *first* link has an `href` value that redirects to your Mastodon profile's URL (such as through a link shortener).
+Alternately, validation will occur if the resolved page's *first* link has an `href` value that redirects to your Mastodon profile's URL (such as through a link shortener).
+
+If validation succeeds, the link to your website will turn green on your profile page. This may take a few minutes even after you deploy the update to your site's HTML. 


### PR DESCRIPTION
Users should know that websites served by CMSes often won't include the static HTML necessary for validation to succeed. That info has been added. Also added what successful validation looks like and noted possible delay in seeing the link color change.