### PR TITLE
Updates limit Option for favourites

### DIFF
--- a/content/en/methods/favourites.md
+++ b/content/en/methods/favourites.md
@@ -32,6 +32,7 @@ Statuses the user has favourited.
 0.0.0 - added\
 2.6.0 - `min_id` added\
 3.3.0 - both `min_id` and `max_id` can be used at the same time now
+4.0.0 - limit defaults to 20. Max is now 40
 
 #### Request
 ##### Headers
@@ -41,7 +42,7 @@ Authorization
 
 ##### Query parameters
 
-max_id 
+max_id
 : **Internal parameter.** Use HTTP `Link` header for pagination.
 
 since_id
@@ -51,7 +52,7 @@ min_id
 : **Internal parameter.** Use HTTP `Link` header for pagination.
 
 limit
-: Integer. Maximum number of results to return. Defaults to 40.
+: Integer. Maximum number of results to return. Defaults to 20. Max 40.
 
 #### Response
 ##### 200: OK


### PR DESCRIPTION
When exploring the API on ruby.social, I came across an inconsistency between the default parameter documented and the actual API call with that parameter omitted. I have updated the documentation to reflect what is actually occurring.

Note: one change highlighted below is a deletion of a trailing whitespace character. Since it seemed that the standard was to not have trailing whitespace at the ends of lines, I left that change in place.

Previously defaulted to 40, now defaults to 20.
Previously no max value stated, now states max value is 40.