### PR TITLE
Remove mention of keybase in the documentation

### DIFF
--- a/content/en/user/contacts.md
+++ b/content/en/user/contacts.md
@@ -29,17 +29,3 @@ You can select certain users to unfollow, or to remove from your followers, by c
 
 From the account settings, you can change your email address, set a new password, revoke active sessions or authorized apps, and enable two-factor authentication.
 
-## Identity proofs {#proofs}
-
-[Link verification](../profile#verification) of profile metadata fields is one way to prove your identity by using rel=me links, but Mastodon also supports a more generalized proof provider subsystem. Currently, the only supported identity provider for this subsystem is Keybase.
-
-### Keybase identity verification {#keybase}
-
-{{< figure src="/assets/keybase.jpg" caption="An identity proof on a profile" >}}
-
-First, sign up for Keybase and generate or upload a GPG public key to your Keybase account. Next, go to "prove more identities". Find your instance if it is available, and if not, contact Keybase for help. Select your Mastodon domain and enter your username. You will be able to prove your identity by authorizing with your Mastodon account and posting a proof message. Once you do this, the identity proof will be established, and your profile will show Keybase as a proven identity.
-
-{{< hint style="danger" >}}
-**Keybase verification is irreversible.** Keybase uses an immutable signature chain for its identity proofs, so once you prove your identity on Keybase, you cannot remove it. You can only revoke your proof by signing a revocation message with your associated private key.
-{{< /hint >}}
-


### PR DESCRIPTION
Keybase has been removed as a verification option: https://github.com/mastodon/mastodon/pull/17045
The documentation should reflect that.