### PR TITLE
Fix formatting in few entities

### DIFF
--- a/content/en/entities/Account.md
+++ b/content/en/entities/Account.md
@@ -234,7 +234,7 @@ aliases: [
 **Description:** When the account was created.\
 **Type:** String (ISO 8601 Datetime)\
 **Version history:**\
-0.1.0 - added
+0.1.0 - added\
 3.4.0 - now resolves to midnight instead of an exact time
 
 ### `last_status_at` {#last_status_at}

--- a/content/en/entities/Admin_Account.md
+++ b/content/en/entities/Admin_Account.md
@@ -117,8 +117,8 @@ aliases: [
 **Description:** The IP address last used to login to this account.\
 **Type:** {{<nullable>}} String\
 **Version history:**\
-2.9.1 - added
-3.5.0 - return type changed from String to [Admin::Ip]({{< relref "entities/Admin_Ip" >}}) due to a bug
+2.9.1 - added\
+3.5.0 - return type changed from String to [Admin::Ip]({{< relref "entities/Admin_Ip" >}}) due to a bug\
 4.0.0 - bug fixed, return type is now a String again
 
 ### `ips` {#ip}
@@ -147,7 +147,7 @@ aliases: [
 **Description:** The current role of the account.\
 **Type:** [Role]({{<relref "entities/role">}})\
 **Version history:**\
-2.9.1 - added, returns a String (enumerable, oneOf `user` `moderator` `admin`)
+2.9.1 - added, returns a String (enumerable, oneOf `user` `moderator` `admin`)\
 4.0.0 - now uses Role entity
 
 ### `confirmed` {#confirmed}

--- a/content/en/entities/Application.md
+++ b/content/en/entities/Application.md
@@ -36,7 +36,7 @@ aliases: [
 **Description:** The website associated with your application.\
 **Type:** {{<nullable>}} String (URL)\
 **Version history:**\
-0.9.9 - added
+0.9.9 - added\
 3.5.1 - this property is now nullable
 
 ### `vapid_key` {#vapid_key}

--- a/content/en/entities/Status.md
+++ b/content/en/entities/Status.md
@@ -188,7 +188,7 @@ aliases: [
 **Description:** The website associated with the application that posted this status.\
 **Type:** {{<nullable>}} String (URL) or null\
 **Version history:**\
-0.9.9 - added
+0.9.9 - added\
 3.5.1 - this property is now nullable
 
 ### `mentions` {#mentions}


### PR DESCRIPTION
Some version infos were missing newline escapes, putting "next" lines into the same line.