### PR TITLE
Add webape to the VPS providers

### DIFF
--- a/content/en/user/run-your-own.md
+++ b/content/en/user/run-your-own.md
@@ -50,6 +50,8 @@ There exist a number of **dedicated Mastodon hosting providers** that take care 
 
 {{< caption-link url="https://cloudplane.org" caption="Cloudplane" >}}
 
+{{< caption-link url="https://webape.site" caption="WebApe" >}}
+
 Managed hosting solutions are great for those who do not have experience or desire to install and maintain software. However, being in charge of all components on your own hardware gives greater control over scaling, performance and customization.
 
 We provide a **DigitalOcean 1-Click Install Image** that you can put on a DigitalOcean droplet of your choosing which essentially gives you everything you would otherwise have after following our installation instructions through an interactive setup wizard.


### PR DESCRIPTION
Hello,

My name is Tio and on top of providing 20+ free services via https://trom.tf/ like Friendica, Peertube, Nextcloud and the like, I also have a project called WebApe https://webape.site/ where I provide full VPS servers that among other services, we provide Mastodon instances too. It is a year old and we already have a few subscribers for the Mastodon package.

Thanks