### PR TITLE
Remove follow scope from example

### DIFF
--- a/content/en/client/authorized.md
+++ b/content/en/client/authorized.md
@@ -28,7 +28,7 @@ To authorize a user, request [GET /oauth/authorize]({{< relref "methods/oauth#au
 ```bash
 https://mastodon.example/oauth/authorize
 ?client_id=CLIENT_ID
-&scope=read+write+follow+push
+&scope=read+write+push
 &redirect_uri=urn:ietf:wg:oauth:2.0:oob
 &response_type=code
 ```
@@ -50,7 +50,7 @@ curl -X POST \
 	-F 'redirect_uri=urn:ietf:wg:oauth:2.0:oob' \
 	-F 'grant_type=authorization_code' \
 	-F 'code=user_authzcode_here' \
-	-F 'scope=read write follow push' \
+	-F 'scope=read write push' \
 	https://mastodon.example/oauth/token
 ```
 

--- a/content/en/client/authorized.md
+++ b/content/en/client/authorized.md
@@ -11,7 +11,7 @@ menu:
 
 When we registered our app and when we will authorize our user, we need to define what exactly our generated token will have permission to do. This is done through the use of OAuth scopes. Each API method has an associated scope, and can only be called if the token being used for authorization has been generated with the corresponding scope.
 
-Scopes must be a subset. When we created our app, we specified `read write follow push` -- we could request all available scopes by specifying `read write follow push`, but it is a better idea to only request what your app will actually need through granular scopes. See [OAuth Scopes]({{< relref "api/oauth-scopes" >}}) for a full list of scopes. Each API method's documentation will also specify the OAuth access level and scope required to call it.
+Scopes must be a subset. When we created our app, we specified `read write push` -- we could request all available scopes by specifying `read write push`, but it is a better idea to only request what your app will actually need through granular scopes. See [OAuth Scopes]({{< relref "api/oauth-scopes" >}}) for a full list of scopes. Each API method's documentation will also specify the OAuth access level and scope required to call it.
 
 ## **Example authorization code flow** {#flow}
 

--- a/content/en/client/token.md
+++ b/content/en/client/token.md
@@ -21,7 +21,7 @@ The first thing we will need to do is to register an application, in order to be
 curl -X POST \
 	-F 'client_name=Test Application' \
 	-F 'redirect_uris=urn:ietf:wg:oauth:2.0:oob' \
-	-F 'scopes=read write follow push' \
+	-F 'scopes=read write push' \
 	-F 'website=https://myapp.example' \
 	https://mastodon.example/api/v1/apps
 ```


### PR DESCRIPTION
`follow` scope is [deprecated](https://docs.joinmastodon.org/api/oauth-scopes/#follow) and included in `read`/`write` scopes.