### PR TITLE
Add required field to account oauth request token

### DIFF
--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -42,6 +42,9 @@ response_type
 client_id
 : {{<required>}} String. The client ID, obtained during app registration.
 
+client_secret
+: {{<required>}} String. The client secret, obtained during app registration.
+
 redirect_uri
 : {{<required>}} String. Set a URI to redirect the user to. If this parameter is set to `urn:ietf:wg:oauth:2.0:oob` then the authorization code will be shown instead. Must match one of the `redirect_uris` declared during app registration.
 


### PR DESCRIPTION
Call fails without required `client_secret` field. Updating docs to save the next dev some trouble.