### PR TITLE
Add explicit bundler group configuration

### DIFF
--- a/content/en/dev/setup.md
+++ b/content/en/dev/setup.md
@@ -49,6 +49,7 @@ You can follow the [pre-requisites instructions from the production guide]({{<re
 Run the following commands in the project directory:
 
 ```sh
+bundle config set --local with 'development'
 bundle install
 yarn install
 ```


### PR DESCRIPTION
See https://github.com/mastodon/mastodon/issues/6161 - people are running into issues running later commands unless bundler is configured to explicitly include the `development` group.