### PR TITLE
Fix API path

### DIFF
--- a/content/en/methods/instance.md
+++ b/content/en/methods/instance.md
@@ -466,7 +466,7 @@ The admin has chosen to show domain blocks to no one. The response body is empty
 ## View extended description {#extended_description}
 
 ```http
-GET /api/v1/example HTTP/1.1
+GET /api/v1/instance/extended_description HTTP/1.1
 ```
 
 Obtain an extended description of this server


### PR DESCRIPTION
The reference HTTP request used an example path `/api/v1/example` instead of the actual path `/api/v1/instance/extended_description`.