### PR TITLE
Remove unnecessary steps from Ruby instructions.

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -74,7 +74,6 @@ And proceed to install rbenv and rbenv-build:
 
 ```bash
 git clone https://github.com/rbenv/rbenv.git ~/.rbenv
-cd ~/.rbenv && src/configure && make -C src
 echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 exec bash


### PR DESCRIPTION
The `src/configure` and `make` steps appear to be obsolete. You can see what those files look like at https://github.com/rbenv/rbenv/tree/master/src

The Makefile just prints this to stderr:
```
Warning: this Makefile is obsolete and kept only for backwards compatibility.
You can remove the `configure && make ...' step from your rbenv setup.
```