### PR TITLE
Add documentation for --days option to tootctl media refresh

### DIFF
--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -690,7 +690,7 @@ Scans for files that do not belong to existing media attachments, and remove the
 
 ### `tootctl media refresh` {#media-refresh}
 
-Refetch remote media attachments from other servers. You must specify the source of media attachments with either `--status`, `--account`, or `--domain`. If an attachment already exists in the database, it will not be overwritten unless you use `--force`.  
+Refetch remote media attachments from other servers. You must specify the source of media attachments with either `--status`, `--account`, `--domain`, or `--days`. If an attachment already exists in the database, it will not be overwritten unless you use `--force`.  
 
 `--account ACCT`
 : String `username@domain` handle of the account

--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -690,7 +690,7 @@ Scans for files that do not belong to existing media attachments, and remove the
 
 ### `tootctl media refresh` {#media-refresh}
 
-Refetch remote media attachments from other servers. You must specify the source of media attachments with either `--status`, `--account`, or `--domain`. If an attachment already exists in the database, it will not be overwritten unless you use `--force`.
+Refetch remote media attachments from other servers. You must specify the source of media attachments with either `--status`, `--account`, or `--domain`. If an attachment already exists in the database, it will not be overwritten unless you use `--force`.  
 
 `--account ACCT`
 : String `username@domain` handle of the account
@@ -701,6 +701,9 @@ Refetch remote media attachments from other servers. You must specify the source
 `--status ID`
 : Local numeric ID of the status in the database.
 
+`--days N`
+: The number of days to limit this task to.
+  
 `--concurrency N`
 : The number of workers to use for this task. Defaults to 5.
 
@@ -715,7 +718,8 @@ Refetch remote media attachments from other servers. You must specify the source
 
 **Version history:**\
 3.0.0 - added\
-3.0.1 - add `--force` and skip already downloaded attachments by default
+3.0.1 - add `--force` and skip already downloaded attachments by default\
+4.0.0 - add `--days`
 
 
 ---


### PR DESCRIPTION
As the title says, this updates the documentation to document the --days option to tootctl's media refresh function introduced in 4.0.0