### PR TITLE
Self-Hosting provider: Syncloud

### DIFF
--- a/content/en/user/run-your-own.md
+++ b/content/en/user/run-your-own.md
@@ -58,6 +58,13 @@ We provide a **DigitalOcean 1-Click Install Image** that you can put on a Digita
 
 That however does assume a single-machine setup. Mastodon scales quite well horizontally. If your needs outgrow the capacity of a single machine, Mastodon can be divided into multiple app servers, background workers, multiple Redis backends, PostgreSQL replicas -- but 1-click install won't cut it.
 
+### Self-Hosting solutions
+
+{{< caption-link url="https://syncloud.org" caption="Syncloud" >}}
+
+
+### Manual
+
 If you're interested in installing everything on your own, proceed here:
 
 {{< page-ref page="admin/prerequisites" >}}


### PR DESCRIPTION
Syncloud open-source platform allows you to run popular services like Mastodon on your device of choice.