### PR TITLE
Document requirement for `updated` timestamp on statuses when processing Update activity

### DIFF
--- a/content/en/spec/activitypub.md
+++ b/content/en/spec/activitypub.md
@@ -33,7 +33,7 @@ Flag
 : Transformed into a report to the moderation team.
 
 Update
-: Refresh vote count on polls. As of Mastodon 3.5.0: edit statuses.
+: Refresh vote count on polls. As of Mastodon 3.5.0, can be used to edit statuses when the `updated` timestamp is present.
 
 Undo
 : Undo a previous Like or Announce.
@@ -81,6 +81,9 @@ url
 
 attributedTo
 : Used to determine the profile which authored the status
+
+updated
+: Used to display the "last edited at" timestamp in the UI to indicate to the user that a status has been edited. Required before an Update activity will be processed. To prevent against race conditions, Mastodon will only process Update payloads with an `updated` timestamp greater than the currently known last `updated` time.
 
 to/cc
 : Used to determine audience and visibility of a status.


### PR DESCRIPTION
After discussion with a new implementer here https://socialhub.activitypub.rocks/t/what-could-be-the-reason-that-my-update-activity-does-not-work/2893, I realized that we don't currently document the need for an `updated` property when processing Update activities. This PR documents that requirement and adds some details about why it exists.