### PR TITLE
Link between /api/v1/preferences and /api/v1/accounts/update_credentials

### DIFF
--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -315,6 +315,8 @@ Update the user's display and preferences.
 2.4.0 - added `source[privacy,sensitive]` parameters\
 2.7.0 - added `discoverable` parameter
 
+{{< page-relref ref="methods/preferences#get" caption="Read preferences using /api/v1/preferences" >}}
+
 #### Request
 
 ##### Headers

--- a/content/en/methods/preferences.md
+++ b/content/en/methods/preferences.md
@@ -31,6 +31,8 @@ Preferences defined by the user in their account settings.
 **Version history:**\
 2.8.0 - added
 
+{{< page-relref ref="methods/accounts#update_credentials" caption="Update user preferences using /api/v1/accounts/update_credentials" >}}
+
 #### Request
 
 ##### Headers


### PR DESCRIPTION
Ref: https://github.com/mastodon/mastodon/pull/22706#issuecomment-1401116403

I wasn’t aware that it was even possible to update user preferences from a third-party app, so this PR adds links both ways to show that it’s possible.