### PR TITLE
Specify reloading of shell when installing Ruby

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -81,6 +81,8 @@ exec bash
 git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 ```
 
+Restart your shell or open a new terminal tab so that the changes take effect. Otherwise you may get a `rbenv: no such command 'install'` error.
+
 Once this is done, we can install the correct Ruby version:
 
 ```bash


### PR DESCRIPTION
The instructions for installing Ruby indicate you need to reload your shell before you can run the 'install' command. This has caused me problems on several of my Mastodon installs since I am not a regular Ruby user. I believe adding this step will provide clarity on an otherwise unclear error message. See https://github.com/rbenv/rbenv#:~:text=init%20does.-,Restart,-your%20shell%20so