### PR TITLE
docs: fix word for edit status

### DIFF
--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -550,7 +550,7 @@ Authorization
 
 ##### Query parameters
 
-max_id 
+max_id
 : **Internal parameter.** Use HTTP `Link` header for pagination.
 
 since_id
@@ -624,7 +624,7 @@ Authorization
 
 ##### Query parameters
 
-max_id 
+max_id
 : **Internal parameter.** Use HTTP `Link` header for pagination.
 
 since_id
@@ -1394,7 +1394,7 @@ Edit a given status to change its text, sensitivity, media attachments, or poll.
 ##### Path parameters
 
 :id
-: {{<required>}} String. The ID of the SOMETHING in the database.
+: {{<required>}} String. The ID of the Status in the database.
 
 ##### Headers
 


### PR DESCRIPTION
I have made a small correction regarding the parameters of the endpoint to edit Status. The expression `SOMETHING` is not appropriate since it is clearly an endpoint that edits Status.

https://docs.joinmastodon.org/methods/statuses/#edit

**From:**

- The ID of the **_SOMETHING_** in the database.

**To:**

- The ID of the **_Status_** in the database.
