### PR TITLE
Fixed links to valid Dart/Flutter libraries

### DIFF
--- a/content/en/client/libraries.md
+++ b/content/en/client/libraries.md
@@ -33,7 +33,7 @@ menu:
 
 ## Dart
 
-* [mastodon](https://pub.dev/packages/mastodon)
+* [mastodon_api](https://pub.dev/packages/mastodon_api)
 
 ## Elixir {#elixir}
 
@@ -109,4 +109,3 @@ menu:
 ## Swift {#swift}
 
 * [MastodonKit](https://github.com/ornithocoder/MastodonKit)
-

--- a/content/en/client/libraries.md
+++ b/content/en/client/libraries.md
@@ -31,7 +31,7 @@ menu:
 
 * [tooter](https://github.com/Shinmera/tooter)
 
-## Dart
+## Dart / Flutter
 
 * [mastodon_api](https://pub.dev/packages/mastodon_api)
 

--- a/content/en/client/libraries.md
+++ b/content/en/client/libraries.md
@@ -34,6 +34,7 @@ menu:
 ## Dart / Flutter
 
 * [mastodon_api](https://pub.dev/packages/mastodon_api)
+* [mastodon_oauth2](https://pub.dev/packages/mastodon_oauth2)
 
 ## Elixir {#elixir}
 


### PR DESCRIPTION
The Mastodon library for Dart mentioned in the documentation appears to be no longer supported, and in fact the Dart and Flutter apps are no longer recommended for use.

Instead, I have added a wrapper library for the Mastodon API that I develop and maintain, and a library to enable OAuth2 authentication in Flutter.

- https://pub.dev/packages/mastodon_api
- https://pub.dev/packages/mastodon_oauth2

I also added the name Flutter since the section title was only Dart.