### PR TITLE
Add missing ruby-build plugin from install guide

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -81,6 +81,12 @@ exec bash
 git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 ```
 
+We need to install the ruby-build plugin. since the ``rbenv install`` command does not ship with rbenv out-of-the-box.
+
+```bash
+git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
+```
+
 Once this is done, we can install the correct Ruby version:
 
 ```bash


### PR DESCRIPTION
Following the mastodon installation guide, when installing the specific ruby version using the command ``rbenv install 3.0.4``, and error will accrue.

Error:
```txt
rbenv: no such command `install'
```

Hence we need to install the ruby-build plugins first.