### PR TITLE
assets/block-domain.png figure is rendered as markup instead of image

### DIFF
--- a/content/en/user/moderating.md
+++ b/content/en/user/moderating.md
@@ -92,7 +92,7 @@ If you and the blocked user are on the same server, the blocked user will not be
 
 ### Hiding an entire server {#block-domain}
 
-![]({{relURL "assets/block-domain.png" }})
+{{< figure src="assets/block-domain.png" caption="Sample of blocking an entire domain." >}}
 
 If you block an entire server:
 


### PR DESCRIPTION
Hi! I noticed that the section for ["Hiding an entire server"](https://docs.joinmastodon.org/user/moderating/#block-domain) currently shows some markup instead of the actual figure:

<img width="400" alt="screenshot of bug" src="https://user-images.githubusercontent.com/19616634/217711859-72ed583f-a8f2-4359-ad38-9320c39dacba.png">

This patch just brings this figure's markup in line with the other figures on the page.