### PR TITLE
Remove references to nonexistent Mastodon 3.6 in filter docs

### DIFF
--- a/content/en/methods/filters.md
+++ b/content/en/methods/filters.md
@@ -16,7 +16,7 @@ aliases: [
 
 ## Server-side (v2) methods {#v2}
 
-Since Mastodon 3.6, filters can contain multiple keywords and are matched server-side. Clients apply the filter action based on [the status's `filtered` attribute]({{< relref "entities/Status#filtered" >}}).
+Since Mastodon 4.0, filters can contain multiple keywords and are matched server-side. Clients apply the filter action based on [the status's `filtered` attribute]({{< relref "entities/Status#filtered" >}}).
 
 ---
 
@@ -1012,7 +1012,7 @@ FilterStatus is not owned by you or does not exist
 
 ## Client-side (v1) methods {#v1}
 
-Prior to Mastodon 3.6, matching filters was done client-size and filters could only contain one phrase to filter against.
+Prior to Mastodon 4.0, matching filters was done client-size and filters could only contain one phrase to filter against.
 
 ---
 


### PR DESCRIPTION
There was no 3.6 release. Server-side filtering was added in 4.0.