### PR TITLE
Correct links to the main mastodon repo (master --> main)

### DIFF
--- a/content/en/admin/scaling.md
+++ b/content/en/admin/scaling.md
@@ -259,7 +259,7 @@ As far as configuring the Redis database goes, basically you can get rid of back
 To reduce the load on your Postgresql server, you may wish to setup hot streaming replication (read replica). [See this guide for an example](https://cloud.google.com/community/tutorials/setting-up-postgres-hot-standby). You can make use of the replica in Mastodon in these ways:
 
 * The streaming API server does not issue writes at all, so you can connect it straight to the replica. But it’s not querying the database very often anyway so the impact of this is little.
-* Use the Makara driver in the web and sidekiq processes, so that writes go to the master database, while reads go to the replica. Let’s talk about that.
+* Use the Makara driver in the web and sidekiq processes, so that writes go to the primary database, while reads go to the replica. Let’s talk about that.
 
 You will have to edit the `config/database.yml` file and replace the `production` section as follows:
 
@@ -279,7 +279,7 @@ production:
         url: postgresql://db_user:db_password@db_host:db_port/db_name
 ```
 
-Make sure the URLs point to wherever your PostgreSQL servers are. You can add multiple replicas. You could have a locally installed pgBouncer with configuration to connect to two different servers based on database name, e.g. “mastodon” going to master, “mastodon_replica” going to the replica, so in the file above both URLs would point to the local pgBouncer with the same user, password, host and port, but different database name. There are many possibilities how this could be setup! For more information on Makara, [see their documentation](https://github.com/taskrabbit/makara#databaseyml).
+Make sure the URLs point to wherever your PostgreSQL servers are. You can add multiple replicas. You could have a locally installed pgBouncer with configuration to connect to two different servers based on database name, e.g. “mastodon” going to the primary, “mastodon_replica” going to the replica, so in the file above both URLs would point to the local pgBouncer with the same user, password, host and port, but different database name. There are many possibilities how this could be setup! For more information on Makara, [see their documentation](https://github.com/taskrabbit/makara#databaseyml).
 
 {{< hint style="warning" >}}
 Sidekiq cannot reliably use read-replicas because even the tiniest replication lag leads to failing jobs due to queued up records not being found.

--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -22,7 +22,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## Base CLI
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/cli.rb" caption="lib/cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/cli.rb" caption="lib/cli.rb" >}}
 
 
 ---
@@ -61,7 +61,7 @@ Show the version of the currently running Mastodon instance.
 
 ## Accounts CLI {#accounts}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/accounts_cli.rb" caption="lib/mastodon/accounts_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/accounts_cli.rb" caption="lib/mastodon/accounts_cli.rb" >}}
 
 
 ---
@@ -345,7 +345,7 @@ Approve new registrations when instance is in approval mode.
 
 ## Cache CLI {#cache}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/cache_cli.rb" caption="lib/mastodon/cache_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/cache_cli.rb" caption="lib/mastodon/cache_cli.rb" >}}
 
 
 ---
@@ -384,7 +384,7 @@ Update hard-cached counters of TYPE by counting referenced records from scratch.
 
 ## Domains CLI {#domains}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/domains_cli.rb" caption="lib/mastodon/domains_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/domains_cli.rb" caption="lib/mastodon/domains_cli.rb" >}}
 
 
 ---
@@ -450,7 +450,7 @@ Crawl the known fediverse by using Mastodon REST API endpoints that expose all k
 
 ## Email domain blocks CLI {#email-domain-blocks}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/email_domain_blocks_cli.rb" caption="lib/mastodon/email_domain_blocks_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/email_domain_blocks_cli.rb" caption="lib/mastodon/email_domain_blocks_cli.rb" >}}
 
 
 ---
@@ -500,7 +500,7 @@ Remove entries from the e-mail domain blocklist.
 
 ## Emoji CLI {#emoji}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/emoji_cli.rb" caption="lib/mastodon/emoji_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/emoji_cli.rb" caption="lib/mastodon/emoji_cli.rb" >}}
 
 
 ---
@@ -572,7 +572,7 @@ Remove all custom emoji.
 
 ## Feeds CLI {#feeds}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/feeds_cli.rb" caption="lib/mastodon/feeds_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/feeds_cli.rb" caption="lib/mastodon/feeds_cli.rb" >}}
 
 
 ---
@@ -617,7 +617,7 @@ Remove all home and list feeds from Redis.
 
 ## Maintenance CLI {#maintenance}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/maintenance_cli.rb" caption="lib/mastodon/maintenance_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/maintenance_cli.rb" caption="lib/mastodon/maintenance_cli.rb" >}}
 
 
 ---
@@ -636,7 +636,7 @@ Fix corrupted database indexes that may have been caused due to changing collati
 
 ## Media CLI {#media}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/media_cli.rb" caption="lib/mastodon/media_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/media_cli.rb" caption="lib/mastodon/media_cli.rb" >}}
 
 
 ---
@@ -748,7 +748,7 @@ Prompts for a media URL, then looks up the status where the media is displayed.
 
 ## Preview Cards CLI {#preview_cards}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/preview_cards_cli.rb" caption="lib/mastodon/preview_cards_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/preview_cards_cli.rb" caption="lib/mastodon/preview_cards_cli.rb" >}}
 
 
 ---
@@ -782,7 +782,7 @@ Remove local thumbnails for preview cards.
 
 ## Search CLI {#search}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/search_cli.rb" caption="lib/mastodon/search_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/search_cli.rb" caption="lib/mastodon/search_cli.rb" >}}
 
 
 ---
@@ -813,7 +813,7 @@ Create or update an ElasticSearch index and populate it. If ElasticSearch is emp
 
 ## Settings CLI {#settings}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/settings_cli.rb" caption="lib/mastodon/settings_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/settings_cli.rb" caption="lib/mastodon/settings_cli.rb" >}}
 
 
 ---
@@ -857,7 +857,7 @@ Set registration to require approval.
 
 ## Statuses CLI {#statuses}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/statuses_cli.rb" caption="lib/mastodon/statuses_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/statuses_cli.rb" caption="lib/mastodon/statuses_cli.rb" >}}
 
 
 ---
@@ -886,7 +886,7 @@ This is a computationally heavy procedure that creates extra database indices be
 
 ## Upgrade CLI {#upgrade}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/upgrade_cli.rb" caption="lib/mastodon/upgrade_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/upgrade_cli.rb" caption="lib/mastodon/upgrade_cli.rb" >}}
 
 
 ---

--- a/content/en/admin/upgrading.md
+++ b/content/en/admin/upgrading.md
@@ -7,7 +7,7 @@ menu:
 ---
 
 {{< hint style="info" >}}
-When a new version of Mastodon comes out, it appears on the [GitHub releases page](https://github.com/mastodon/mastodon/releases). Please mind that running unreleased code from the `master` branch, while possible, is not recommended.
+When a new version of Mastodon comes out, it appears on the [GitHub releases page](https://github.com/mastodon/mastodon/releases). Please mind that running unreleased code from the `main` branch, while possible, is not recommended.
 {{< /hint >}}
 
 Mastodon releases correspond to git tags. Before attempting an upgrade, look up the desired release on the [GitHub releases page](https://github.com/mastodon/mastodon/releases). The page will contain a **changelog** describing everything you need to know about what's different, as well as **specific upgrade instructions**.

--- a/content/en/api/guidelines.md
+++ b/content/en/api/guidelines.md
@@ -123,9 +123,9 @@ If `whole_word` is true, the client app should do the following:
 
 Please check `app/javascript/mastodon/selectors/index.js` and `app/lib/feed_manager.rb` in the Mastodon source code for more details.
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/javascript/mastodon/selectors/index.js" caption="app/javascript/mastodon/selectors/index.js" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/javascript/mastodon/selectors/index.js" caption="app/javascript/mastodon/selectors/index.js" >}}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/lib/feed_manager.rb" caption="app/lib/feed_manager.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/lib/feed_manager.rb" caption="app/lib/feed_manager.rb" >}}
 
 ## Focal points for cropping media thumbnails {#focal-points}
 

--- a/content/en/dev/routes.md
+++ b/content/en/dev/routes.md
@@ -7,7 +7,7 @@ menu:
     parent: dev
 ---
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/config/routes.rb" caption="config/routes.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/config/routes.rb" caption="config/routes.rb" >}}
 
 ## Explanation of routes {#routes}
 

--- a/content/en/entities/Account.md
+++ b/content/en/entities/Account.md
@@ -442,8 +442,8 @@ aliases: [
 
 {{< page-relref ref="methods/accounts" caption="accounts API methods" >}}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/account_serializer.rb" caption="app/serializers/rest/account_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/account_serializer.rb" caption="app/serializers/rest/account_serializer.rb" >}}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/credential_account_serializer.rb" caption="app/serializers/rest/credential_account_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/credential_account_serializer.rb" caption="app/serializers/rest/credential_account_serializer.rb" >}}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/muted_account_serializer.rb" caption="app/serializers/rest/muted_account_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/muted_account_serializer.rb" caption="app/serializers/rest/muted_account_serializer.rb" >}}

--- a/content/en/entities/Admin_Account.md
+++ b/content/en/entities/Admin_Account.md
@@ -210,4 +210,4 @@ aliases: [
 
 {{< page-relref ref="methods/admin/accounts" caption="admin/accounts API methods" >}}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/admin/account_serializer.rb" caption="app/serializers/rest/admin/account_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/admin/account_serializer.rb" caption="app/serializers/rest/admin/account_serializer.rb" >}}

--- a/content/en/entities/Admin_Report.md
+++ b/content/en/entities/Admin_Report.md
@@ -170,7 +170,7 @@ aliases: [
 
 {{< page-relref page="methods/admin/reports" caption="admin/reports API methods">}}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/admin/report_serializer.rb" caption="app/serializers/rest/admin/report_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/admin/report_serializer.rb" caption="app/serializers/rest/admin/report_serializer.rb" >}}
 
 
 

--- a/content/en/entities/Application.md
+++ b/content/en/entities/Application.md
@@ -66,4 +66,4 @@ aliases: [
 
 {{< page-relref ref="entities/Status#application" caption="Status (`application` attribute)" >}}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/serializers/rest/application_serializer.rb" caption="app/serializers/rest/application_serializer.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/application_serializer.rb" caption="app/serializers/rest/application_serializer.rb" >}}

--- a/content/en/entities/Error.md
+++ b/content/en/entities/Error.md
@@ -117,7 +117,7 @@ Error: There was a temporary problem serving your request, please try again. App
 
 ## See also
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/controllers/api/base_controller.rb" caption="app/controllers/api/base_controller.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/controllers/api/base_controller.rb" caption="app/controllers/api/base_controller.rb" >}}
 
 
 

--- a/content/en/spec/activitypub.md
+++ b/content/en/spec/activitypub.md
@@ -13,7 +13,7 @@ Sample payloads will be added at a future date.
 
 ## Status federation {#status}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/lib/activitypub/activity.rb" caption="app/lib/activitypub/activity.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/lib/activitypub/activity.rb" caption="app/lib/activitypub/activity.rb" >}}
 
 ### Supported activities for statuses
 
@@ -237,7 +237,7 @@ published
 
 ## JSON-LD Namespacing {#namespaces}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/lib/activitypub/adapter.rb" caption="app/lib/activitypub/adapter.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/lib/activitypub/adapter.rb" caption="app/lib/activitypub/adapter.rb" >}}
 
 ### Mastodon extensions (`toot:`) {#toot}
 

--- a/content/en/spec/oauth.md
+++ b/content/en/spec/oauth.md
@@ -17,7 +17,7 @@ To obtain an OAuth token for a Mastodon website, make sure that you allow your u
 
 The following descriptions are taken from the [Doorkeeper documentation](https://github.com/doorkeeper-gem/doorkeeper/wiki/API-endpoint-descriptions-and-examples). Mastodon uses Doorkeeper to implement OAuth 2. For more information on how to use these endpoints, see the [API documentation for OAuth.]({{< relref "methods/oauth" >}})
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/config/initializers/doorkeeper.rb" caption="Doorkeeper config initializer" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/config/initializers/doorkeeper.rb" caption="Doorkeeper config initializer" >}}
 
 ### Authorization endpoint (RFC 6749 Section 3.1) {#authorization}
 

--- a/content/en/spec/security.md
+++ b/content/en/spec/security.md
@@ -9,7 +9,7 @@ menu:
 
 ## HTTP Signatures {#http}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/lib/request.rb" caption="app/lib/request.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/lib/request.rb" caption="app/lib/request.rb" >}}
 
 [HTTP Signatures](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures) is a specification for signing HTTP messages by using a `Signature:` header with your HTTP request. Mastodon requires the use of HTTP Signatures in order to validate that any activity received was authored by the actor generating it. When secure mode is enabled, all GET requests require HTTP signatures as well.
 
@@ -99,7 +99,7 @@ Content-Type: application/ld+json; profile="http://www.w3.org/ns/activitystreams
 
 ### Verifying HTTP signatures {#http-verify}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/controllers/concerns/signature_verification.rb" caption="app/controllers/concerns/signature_verification.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/controllers/concerns/signature_verification.rb" caption="app/controllers/concerns/signature_verification.rb" >}}
 
 Consider the following request:
 
@@ -133,7 +133,7 @@ Mastodon verifies the signature using the following algorithm:
 
 ## Linked Data Signatures {#ld}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/app/lib/activitypub/linked_data_signature.rb" caption="app/lib/activitypub/linked_data_signature.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/lib/activitypub/linked_data_signature.rb" caption="app/lib/activitypub/linked_data_signature.rb" >}}
 
 {{< hint style="warning" >}}
 Mastodon's current implementation of LD Signatures is outdated due to a change in the JSON-LD `@context` between the drafting stage and finalization stage of the specification. Mastodon expects a `type` of `RsaSignature2017` while later drafts instead define `RsaSignature2018` via the namespace `https://w3id.org/security/v2`. Furthermore, the LD Signatures specification as a whole has been superseded by the [Verifiable Credential Data Integrity 1.0](https://w3c.github.io/vc-data-integrity/) specification, which is largely incompatible with the earlier LD Signature spec. For this reason, it is not advised to implement support for LD Signatures.

--- a/content/zh-cn/admin/scaling.md
+++ b/content/zh-cn/admin/scaling.md
@@ -259,7 +259,7 @@ Redis被广泛使用于应用，但是某些用途比其他用途更重要。主
 为了减轻你的Postgresql服务器负担，你可以使用热流复制（hot streaming replication）（只读副本（read replica））。有关示例，请参见[该指南](https://cloud.google.com/community/tutorials/setting-up-postgres-hot-standby)。你可以给以下Mastodon用途使用副本（replica）：
 
 * streaming API 服务器无需写入，因此你可以将其直接使用副本（replica）。但由于 streaming API 服务器不经常查询数据库，这样的优化影响很小。
-* 使用 Makara 驱动 web 与 sidekiq 进程，这样可以实现从主（master）数据库写，从副本（replica）读。让我们开始吧。
+* 使用 Makara 驱动 web 与 sidekiq 进程，这样可以实现从主（primary）数据库写，从副本（replica）读。让我们开始吧。
 
 编辑 `config/database.yml` 文件，将 `production` 替换为如下内容：
 

--- a/content/zh-cn/admin/tootctl.md
+++ b/content/zh-cn/admin/tootctl.md
@@ -23,7 +23,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 基础命令
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/cli.rb" caption="lib/cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/cli.rb" caption="lib/cli.rb" >}}
 
 ### `tootctl self-destruct` {#self-destruct}
 
@@ -51,7 +51,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 帐户相关命令 {#accounts}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/accounts_cli.rb" caption="lib/mastodon/accounts_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/accounts_cli.rb" caption="lib/mastodon/accounts_cli.rb" >}}
 
 ### `tootctl accounts rotate` {#accounts-rotate}
 
@@ -208,7 +208,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 缓存相关命令 {#cache}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/cache_cli.rb" caption="lib/mastodon/cache_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/cache_cli.rb" caption="lib/mastodon/cache_cli.rb" >}}
 
 ### `tootctl cache clear` {#cache-clear}
 
@@ -232,7 +232,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 域名相关命令 {#domains}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/domains_cli.rb" caption="lib/mastodon/domains_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/domains_cli.rb" caption="lib/mastodon/domains_cli.rb" >}}
 
 ### `tootctl domains purge` {#domains-purge}
 
@@ -269,7 +269,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## Emoji相关命令 {#emoji}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/emoji_cli.rb" caption="lib/mastodon/emoji_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/emoji_cli.rb" caption="lib/mastodon/emoji_cli.rb" >}}
 
 ### `tootctl emoji import` {#emoji-import}
 
@@ -301,7 +301,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 时间流（Feeds）相关命令 {#feeds}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/feeds_cli.rb" caption="lib/mastodon/feeds_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/feeds_cli.rb" caption="lib/mastodon/feeds_cli.rb" >}}
 
 ### `tootctl feeds build` {#feeds-build}
 
@@ -327,7 +327,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 媒体相关命令 {#media}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/media_cli.rb" caption="lib/mastodon/media_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/media_cli.rb" caption="lib/mastodon/media_cli.rb" >}}
 
 ### `tootctl media remove` {#media-remove}
 
@@ -390,7 +390,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 预览卡片（Preview Cards）相关命令 {#preview_cards}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/preview_cards_cli.rb" caption="lib/mastodon/preview_cards_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/preview_cards_cli.rb" caption="lib/mastodon/preview_cards_cli.rb" >}}
 
 ### `tootctl preview_cards remove` {#preview_cards-remove}
 
@@ -409,7 +409,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 搜索相关命令 {#search}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/search_cli.rb" caption="lib/mastodon/search_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/search_cli.rb" caption="lib/mastodon/search_cli.rb" >}}
 
 ### `tootctl search deploy` {#search-deploy}
 
@@ -425,7 +425,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 站点设定相关命令 {#settings}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/settings_cli.rb" caption="lib/mastodon/settings_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/settings_cli.rb" caption="lib/mastodon/settings_cli.rb" >}}
 
 ### `tootctl settings registrations open` {#settings-registrations-open}
 
@@ -443,7 +443,7 @@ RAILS_ENV=production bin/tootctl help
 
 ## 嘟文相关命令 {#statuses}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/master/lib/mastodon/statuses_cli.rb" caption="lib/mastodon/statuses_cli.rb" >}}
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/lib/mastodon/statuses_cli.rb" caption="lib/mastodon/statuses_cli.rb" >}}
 
 ### `tootctl statuses remove` {#statuses-remove}
 

--- a/content/zh-cn/admin/upgrading.md
+++ b/content/zh-cn/admin/upgrading.md
@@ -7,7 +7,7 @@ menu:
 ---
 
 {{< hint style="info" >}}
-当一个新的Mastodon版本释出后，它将出现在[GitHub releases页面](https://github.com/mastodon/mastodon/releases)。请注意：运行来自`master`分支的未释出代码，虽然可以进行，但不推荐这样做。
+当一个新的Mastodon版本释出后，它将出现在[GitHub releases页面](https://github.com/mastodon/mastodon/releases)。请注意：运行来自`main`分支的未释出代码，虽然可以进行，但不推荐这样做。
 {{< /hint >}}
 
 Mastodon版本与git tags一致。在尝试升级之前，请至[GitHub releases页面](https://github.com/mastodon/mastodon/releases)查找所需版本。该页面包含了一个**更新日专**，其中描述你需要了解的所有差异，以及**特定的升级指令**。


### PR DESCRIPTION
The current documentation still links to the `master` branch on the main mastodon repo which has been renamed to `main`.

Additionally the language on the scaling page uses `master` instead of `primary`, which I've added in a second commit. If you want to include this is up to you, but considering we use `replica` instead of `slave` for the secondary server already it makes sense to do the same for `master`

