### PR TITLE
Fix an image rendered as raw markdown

### DIFF
--- a/content/en/user/moderating.md
+++ b/content/en/user/moderating.md
@@ -92,7 +92,7 @@ If you and the blocked user are on the same server, the blocked user will not be
 
 ### Hiding an entire server {#block-domain}
 
-![]({{relURL "assets/block-domain.png" }})
+{{< figure src="assets/block-domain.png" caption="The block domain dialog reminds that usually muting a few users is preferable" >}}
 
 If you block an entire server:
 


### PR DESCRIPTION
The image appeared as:
```
![]({{relURL "assets/block-domain.png" }})
```
(raw markdown code)

Using a figure as for the other images in this page fixes it, at least
locally.
