### PR TITLE
Fix the description of `media_attachments` in `StatusEdit`

### DIFF
--- a/content/en/entities/StatusEdit.md
+++ b/content/en/entities/StatusEdit.md
@@ -105,7 +105,7 @@ aliases: [
 
 ### `media_attachments` {#media_attachments}
 
-**Description:** The current state of the poll options at this revision. Note that edits changing the poll options will be collapsed together into one edit, since this action resets the poll.\
+**Description:** The current state of the media attachments at this revision.\
 **Type:** Array of [MediaAttachment]({{<relref "entities/MediaAttachment">}})\
 **Version history:**\
 3.5.0 - added


### PR DESCRIPTION
Corrects a copy/paste error from the earlier `poll` field.