### PR TITLE
Improve instructions for setting up the development environment

### DIFF
--- a/content/en/dev/setup.md
+++ b/content/en/dev/setup.md
@@ -49,31 +49,41 @@ You can follow the [pre-requisites instructions from the production guide]({{<re
 Run the following commands in the project directory:
 
 ```sh
+bundle config set --local path vendor/bundle
 bundle install
-yarn install
+yarn
 ```
+
+{{<hint style="info">}}
+On some operating systems, such as Debian and Fedora, `yarn` has been renamed to `yarnpkg`. On these systems, run `yarnpkg` instead of `yarn`.
+{{</hint>}}
 
 In the development environment, Mastodon will use PostgreSQL as the currently signed-in Linux user using the `ident` method. Ensure that you have created a Postgres user and database for your current signed-in user:
 
 ```sh
-sudo -u postgres createuser $YOUR_USERNAME_HERE --createdb
+sudo -u postgres createuser $USER --createdb
 ```
 
-You can now create the databases `mastodon_development` and `mastodon_test`, load the schema into them, and create seed data defined in `db/seeds/` into `mastodon_development`.
+{{<hint style="info">}}
+If the above fails, you may have to run the following to initialize PostgreSQL:
 
 ```sh
-rails db:setup
+sudo postgresql-setup --initdb
+```
+{{</hint>}}
+
+Finally, run:
+
+```sh
+RAILS_ENV=development bundle exec rails db:setup
 ```
 
-You can now launch `http://localhost:3000` in your browser and log in with the default admin user (`admin@localhost:3000` / `mastodonadmin`).
+This creates the databases `mastodon_development` and `mastodon_test`, loads the schema into them, and inserts seed data defined in `db/seeds/` into `mastodon_development`.
 
-{{<hint style="warning">}}
-By default, Mastodon will run on port 3000. If you configure a different port for it, the generated admin account will use that number as well.
-{{</hint>}}
 
 ### Running {#running}
 
-There are multiple processes that need to be run for the full set of Mastodon’s functionality, although they can be selectively omitted. To run all of them with just one command, you can install and use Foreman:
+There are multiple processes that need to be run for the full set of Mastodon's functionality, although they can be selectively omitted. To run all of them with just one command, you can install and use Foreman:
 
 ```sh
 gem install foreman --no-document
@@ -81,6 +91,12 @@ foreman start
 ```
 
 This will start processes defined in `Procfile.dev`, which will give you: A Rails server, a Webpack server, a streaming API server, and Sidekiq. Of course, you can run any of those things stand-alone depending on your needs.
+
+You can now launch `http://localhost:3000` in your browser and log in with the default admin user (`admin@localhost:3000` / `mastodonadmin`).
+
+{{<hint style="warning">}}
+By default, Mastodon will run on port 3000. If you configure a different port for it, the generated admin account will use that number as well.
+{{</hint>}}
 
 ## Useful commands for testing {#testing}
 


### PR DESCRIPTION
This is another attempt at #1024, because I think there is still some room for improvement after @trwnh's edits.

Changes:

- Fix commands and clarify instructions.
- Add some tips for operating system-specific quirks.
- Remove typographic quotes.
- Add a trailing newline.