### PR TITLE
Clarify that apps verify_credentials requires app token + read

### DIFF
--- a/content/en/methods/apps.md
+++ b/content/en/methods/apps.md
@@ -84,7 +84,7 @@ GET /api/v1/apps/verify_credentials HTTP/1.1
 Confirm that the app's OAuth2 credentials work.
 
 **Returns:** [Application]({{< relref "entities/application" >}}), but without `client_id` or `client_secret`\
-**OAuth level:** App token\
+**OAuth level:** App token + `read`\
 **Version history:**\
 2.0.0 - added\
 2.7.2 - now returns `vapid_key`
@@ -94,7 +94,7 @@ Confirm that the app's OAuth2 credentials work.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <app token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK


### PR DESCRIPTION
As per [the controller](https://github.com/mastodon/mastodon/blob/6e8711ff91e01212ac7c82de6349fa2b143582e2/app/controllers/api/v1/apps/credentials_controller.rb#L4) this endpoint requires and app token with the `read` scope.