### PR TITLE
Update language attribute restrictions in API

### DIFF
--- a/content/en/entities/Account.md
+++ b/content/en/entities/Account.md
@@ -388,9 +388,10 @@ aliases: [
 #### `source[language]` {#source-language}
 
 **Description:** The default posting language for new statuses.\
-**Type:** String (ISO 639-1 language two-letter code) or empty string\
+**Type:** String (well-formed BCP 47 language tag, but parts other than language subtag may be discarded) or empty string\
 **Version history:**\
 2.4.2 - added
+4.1.0 - accept BCP 47
 
 #### `source[follow_requests_count]` {#follow_requests_count}
 

--- a/content/en/entities/Admin_Account.md
+++ b/content/en/entities/Admin_Account.md
@@ -131,9 +131,10 @@ aliases: [
 ### `locale` {#locale}
 
 **Description:** The locale of the account.\
-**Type:** String (ISO 639 Part 1 two-letter language code)\
+**Type:** String (well-formed BCP 47 language tag, but parts other than language subtag may be discarded)\
 **Version history:**\
 2.9.1 - added
+4.1.0 - accept BCP 47
 
 ### `invite_request` {#invite_request}
 

--- a/content/en/entities/Instance.md
+++ b/content/en/entities/Instance.md
@@ -265,9 +265,10 @@ aliases: [
 ### `languages` {#languages}
 
 **Description:** Primary languages of the website and its staff.\
-**Type:** Array of String (ISO 639-1 two-letter code)\
+**Type:** Array of String (well-formed BCP 47 language tag, but parts other than language subtag may be discarded)\
 **Version history:**\
 4.0.0 - added
+4.1.0 - accept BCP 47
 
 ### `configuration` {#configuration}
 

--- a/content/en/entities/Preferences.md
+++ b/content/en/entities/Preferences.md
@@ -47,9 +47,10 @@ aliases: [
 ### `posting:default:language` {#posting-default-language}
 
 **Description:** Default language for new posts. Equivalent to [CredentialAccount#source\[language\]]({{< relref "entities/Account#source-language" >}})\
-**Type:** {{<nullable>}} String (ISO 639-1 language two-letter code), or null\
+**Type:** {{<nullable>}} String (well-formed BCP 47 language tag, but parts other than language subtag may be discarded), or null\
 **Version history:**\
 2.8.0 - added
+4.1.0 - accept BCP 47
 
 ### `reading:expand:media` {#reading-expand-media}
 

--- a/content/en/entities/Relationship.md
+++ b/content/en/entities/Relationship.md
@@ -65,9 +65,10 @@ aliases: [
 ### `languages` {#languages}
 
 **Description:** Which languages are you following from this user?\
-**Type:** Array of String (ISO 639-1 language two-letter code)\
+**Type:** Array of String (well-formed BCP 47 language tag, but parts other than language subtag may be discarded)\
 **Version history:**\
 4.0.0 - added
+4.1.0 - accept BCP 47
 
 ### `followed_by` {#followed_by}
 

--- a/content/en/entities/ScheduledStatus.md
+++ b/content/en/entities/ScheduledStatus.md
@@ -169,9 +169,10 @@ Returned from `GET /api/v1/scheduled_statuses`:
 #### `params[language]` {#params-language}
 
 **Description:** The language that will be used for the status.\
-**Type:** {{<nullable>}} String (ISO 639-1 two-letter language code)\
+**Type:** {{<nullable>}} String (well-formed BCP 47 language tag, but parts other than language subtag may be discarded)\
 **Version history:**\
 2.7.0 - added
+4.1.0 - accept BCP 47
 
 #### `params[application_id]` {#params-application_id}
 

--- a/content/en/entities/Status.md
+++ b/content/en/entities/Status.md
@@ -278,9 +278,10 @@ aliases: [
 ### `language` {#language}
 
 **Description:** Primary language of this status.\
-**Type:** {{<nullable>}} String (ISO 639 Part 1 two-letter language code) or null\
+**Type:** {{<nullable>}} String (well-formed BCP 47 language tag, but parts other than language subtag may be discarded) or null\
 **Version history:**\
 1.4.0 - added
+4.1.0 - accept BCP 47
 
 ### `text` {#text}
 

--- a/content/en/entities/Translation.md
+++ b/content/en/entities/Translation.md
@@ -32,9 +32,10 @@ aliases: [
 ### `detected_source_language` {#detected_source_language}
 
 **Description:** The language of the source text, as auto-detected by the machine translation provider.\
-**Type:** String (ISO 639 language code)\
+**Type:** String (well-formed BCP 47 language tag, but parts other than language subtag may be discarded)\
 **Version history:**\
 4.0.0 - added
+4.1.0 - accept BCP 47
 
 ### `provider` {#provider}
 

--- a/content/en/entities/V1_Instance.md
+++ b/content/en/entities/V1_Instance.md
@@ -240,9 +240,10 @@ aliases: [
 ### `languages` {#languages}
 
 **Description:** Primary languages of the website and its staff.\
-**Type:** Array of String (ISO 639-1 two-letter code)\
+**Type:** Array of String (well-formed BCP 47 language tag, but parts other than language subtag may be discarded)\
 **Version history:**\
 2.3.0 - added
+4.1.0 - accept BCP 47
 
 ### `registrations` {#registrations}
 

--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -361,7 +361,7 @@ source[sensitive]
 : Boolean. Whether to mark authored statuses as sensitive by default.
 
 source[language]
-: String. Default language to use for authored statuses (ISO 6391)
+: String. Default language to use for authored statuses (in well-formed BCP 47 language tag, but parts other than language subtag may be discarded by the system).
 
 #### Response
 
@@ -1200,7 +1200,7 @@ notify
 : Boolean. Receive notifications when this account posts a status? Defaults to false.
 
 languages
-: Array of String (ISO 639-1 language two-letter code). Filter received statuses for these languages. If not provided, you will receive this account's posts in all languages.
+: Array of String (well-formed BCP 47 language tag, but parts other than language subtag may be discarded). Filter received statuses for these languages. If not provided, you will receive this account's posts in all languages.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -52,7 +52,7 @@ force_login
 : Boolean. Forces the user to re-login, which is necessary for authorizing with multiple accounts from the same instance.
 
 lang
-: String. The ISO 639-1 two-letter language code to use while rendering the authorization form.
+: String. The well-formed BCP 47 language tag (parts other than language subtag may be discarded by the system) to use while rendering the authorization form.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -75,7 +75,7 @@ visibility
 : String. Sets the visibility of the posted status to `public`, `unlisted`, `private`, `direct`.
 
 language
-: String. ISO 639 language code for this status.
+: String. Well-formed BCP 47 language tag for this status (parts other than language subtag may be discarded by the system).
 
 scheduled_at
 : String. ISO 8601 Datetime at which to schedule a status. Providing this parameter will cause ScheduledStatus to be returned instead of Status. Must be at least 5 minutes in the future.
@@ -546,7 +546,7 @@ Translate the status content into some language.
 ##### Form data parameters
 
 lang
-: String (ISO 639 language code). The status content will be translated into this language. Defaults to the user's current locale.
+: String (well-formed BCP 47 language tag, but parts other than language subtag may be discarded). The status content will be translated into this language. Defaults to the user's current locale.
 
 ##### Headers
 
@@ -1478,7 +1478,7 @@ sensitive
 : Boolean. Whether the status should be marked as sensitive.
 
 language
-: String. ISO 639 language code for the status.
+: String. Well-formed BCP 47 language tag for the status (parts other than language subtag may be discarded by the system).
 
 media_ids[]
 : Array of String. Include Attachment IDs to be attached as media. If provided, `status` becomes optional, and `poll` cannot be used.


### PR DESCRIPTION
As far as I read the [current implementation](https://github.com/mastodon/mastodon/blob/main/app/helpers/languages_helper.rb), the software technically processes hyphened language tags and _does_ legally emit ISO 639-3 as well as ISO 639-1 codes. That means even though Mastodon itself is not ready to support the most of advanced language tags, it has no problem inputting/outputting those codes in API. Thus we can:

- remove some outdated descriptions limiting to "ISO 639-1 two-letter code", which no more applies
- accept well-formed BCP 47 language tags, with notes that Mastodon probably ignore additional information

https://github.com/mastodon/mastodon/issues/19302 is a corroboration that a language tag doesn't break the system.

The rationale of this change is discussed in https://github.com/mastodon/mastodon/issues/23541.

Closes https://github.com/mastodon/mastodon/issues/23541.

* Note: "language subtag" in BCP 47 &ap; ISO 639-1 &cup; ISO 639-3