### PR TITLE
Fix typo s/statuses/accounts

### DIFF
--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -630,7 +630,7 @@ limit
 #### Response
 ##### 200: OK
 
-A list of statuses that boosted the status
+A list of accounts that boosted the status
 
 ```json
 [


### PR DESCRIPTION
Fix typo on this sentence under "See who boosted a status" https://docs.joinmastodon.org/methods/statuses/#200-ok-5
<img width="731" alt="Screenshot 2023-04-06 at 8 46 31 PM" src="https://user-images.githubusercontent.com/2296/230382933-1ccacf11-b58d-4ad5-b3c0-a8a4ecf5e73c.png">
