### PR TITLE
fix "ActivityPub" format mention to be AS 2.0

### DIFF
--- a/content/en/user/moving.md
+++ b/content/en/user/moving.md
@@ -13,7 +13,7 @@ menu:
 
 At any time you want, you can go to Settings &gt; Export and download a CSV file for your current followed accounts, your currently created lists, your currently blocked accounts, your currently muted accounts, and your currently blocked domains. Your following, blocking, muting, and domain-blocking lists can be imported at Settings &gt; Import, where they can either be merged or overwritten.
 
-Requesting an archive of your posts and media can be done once every 7 days, and can be downloaded in ActivityPub JSON format. Mastodon currently does not support importing posts or media due to technical limitations, but your archive can be viewed by any software that understands how to parse ActivityPub documents.
+Requesting an archive of your posts and media can be done once every 7 days, and can be downloaded in Activity Streams 2.0 JSON format. Mastodon currently does not support importing posts or media due to technical limitations, but your archive can be viewed by any software that understands how to parse Activity Streams 2.0 documents.
 
 ## Redirecting or moving your profile {#migration}
 


### PR DESCRIPTION
There is no "ActivityPub JSON format", ActivityPub is a protocol and has no "formats" per se. ActivityPub uses the Activity Streams 2.0 format https://www.w3.org/TR/activitystreams-core/.

Verified that Mastodon's post export is Activity Streams 2.0 JSON: https://chat.indieweb.org/dev/2023-04-22#t1682203049226300