### PR TITLE
feat: document the usage of Letter Opener for development emails

### DIFF
--- a/content/en/dev/setup.md
+++ b/content/en/dev/setup.md
@@ -82,6 +82,12 @@ foreman start
 
 This will start processes defined in `Procfile.dev`, which will give you: A Rails server, a Webpack server, a streaming API server, and Sidekiq. Of course, you can run any of those things stand-alone depending on your needs.
 
+## Working with emails in development
+
+In development mode, Mastodon will use a gem called [Letter Opener](https://github.com/ryanb/letter_opener) for "sending" emails, which allows you to debug emails in your browser, without actually having to send emails via an SMTP server.
+
+In order to work with emails, you'll need Sidekiq, Redis and PostgreSQL running, and then emails can be viewed by visiting: `http://localhost:3000/letter_opener/`
+
 ## Useful commands for testing {#testing}
 
 `rspec`

--- a/content/en/dev/setup.md
+++ b/content/en/dev/setup.md
@@ -88,6 +88,8 @@ In development mode, Mastodon will use a gem called [Letter Opener](https://gith
 
 In order to work with emails, you'll need Sidekiq, Redis and PostgreSQL running, and then emails can be viewed by visiting: `http://localhost:3000/letter_opener/`
 
+If you're developing in docker, you'll need to set the `REMOTE_DEV=true` environment variable.
+
 ## Useful commands for testing {#testing}
 
 `rspec`


### PR DESCRIPTION
I'd hit into this when setting up my development environment, as I'd tried to use [Mailhog](https://github.com/mailhog/MailHog/) as my smtp server, but was seemingly not receiving any emails. I found some information that indicated that the project was using the letter opener gem, and that I needed to have sidekiq running for emails to be "delivered" (I didn't currently have it running).

- https://github.com/mastodon/mastodon/issues/3435

