### PR TITLE
Remove the admin/ prefix on Admin APIs for consistency

### DIFF
--- a/content/en/methods/admin/accounts.md
+++ b/content/en/methods/admin/accounts.md
@@ -3,7 +3,7 @@ title: admin/accounts API methods
 description: Perform moderation actions with accounts.
 menu:
   docs:
-    name: admin/accounts
+    name: accounts
     parent: methods-admin
     identifier: methods-admin-accounts
 aliases: [

--- a/content/en/methods/admin/domain_blocks.md
+++ b/content/en/methods/admin/domain_blocks.md
@@ -3,7 +3,7 @@ title: admin/domain_blocks API methods
 description: Disallow certain domains to federate.
 menu:
   docs:
-    name: admin/domain_blocks
+    name: domain_blocks
     parent: methods-admin
     identifier: methods-admin-domain_blocks
 aliases: [

--- a/content/en/methods/admin/reports.md
+++ b/content/en/methods/admin/reports.md
@@ -3,7 +3,7 @@ title: admin/reports API methods
 description: Perform moderation actions with reports.
 menu:
   docs:
-    name: admin/reports
+    name: reports
     parent: methods-admin
     identifier: methods-admin-reports
 aliases: [

--- a/content/en/methods/admin/trends.md
+++ b/content/en/methods/admin/trends.md
@@ -3,7 +3,7 @@ title: admin/trends API methods
 description: TODO
 menu:
   docs:
-    name: admin/trends
+    name: trends
     parent: methods-admin
     identifier: methods-admin-trends
 aliases: [


### PR DESCRIPTION
Just noticed this whilst looking something up in the documentation, several of the admin API methods had `admin/` prefixed to them when the other sub-navigation items do not:

<img width="250" alt="Screenshot 2023-05-31 at 2 51 10 am" src="https://github.com/mastodon/documentation/assets/30827/bbc070b5-3b76-4aea-a586-87dc0d3b86f3">

