### PR TITLE
Update to libraries page following full review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ![Mastodon](https://i.imgur.com/NhZc40l.png)
 ====
 
+The documentation currently uses Hugo to generate a static site from Markdown.
+
 View the documentation at <https://docs.joinmastodon.org>

--- a/content/en/client/libraries.md
+++ b/content/en/client/libraries.md
@@ -1,18 +1,22 @@
 ---
 title: Libraries and implementations
-description: Interface with the Mastodon API in the programming language of your choice.
+description: Code, libraries and SDKs for the Mastodon API in a range of programming languages.
 menu:
   docs:
     weight: 60
     parent: client
 ---
 
-## Apex (Salesforce) {#apex-salesforce}
+Thank you to our awesome developer community, for supporting the project with a wide range of implementations of the API. If you have built a library or SDK for the Mastodon API, [let us know](https://github.com/mastodon/mastodon/discussions) about it, and it may be included below in a future update.
 
-* [apex-mastodon](https://github.com/tzmfreedom/apex-mastodon)
+Remember to check how recently the library was updated, and whether it includes the API features you may want to use.
 
+## Arduino / ESP32 / IoT {#arduino-iot}
+
+* [lyuba](https://github.com/ringtailsoftware/lyuba)
 ## C# (.NET Standard) {#c-net-standard}
 
+* [MastodonAPI](https://github.com/golf1052/MastodonAPI)
 * [Mastodot](https://github.com/yamachu/Mastodot)
 * [Mastonet](https://github.com/glacasa/Mastonet)
 * [TootNet](https://github.com/cucmberium/TootNet)
@@ -23,26 +27,33 @@ menu:
 
 * [mastodonpp](https://schlomp.space/tastytea/mastodonpp)
 
-## Crystal {#crystal}
-
-* [mastodon.cr](https://github.com/decors/mastodon.cr)
-
 ## Common Lisp {#common-lisp}
 
 * [tooter](https://github.com/Shinmera/tooter)
 
+## Crystal {#crystal}
+
+* [mastodon-api-crystal](https://github.com/renatolond/mastodon-api-crystal)
+
 ## Dart
 
-* [mastodon](https://pub.dev/packages/mastodon)
+* [mastodon-api](https://github.com/mastodon-dart/mastodon-api)
+* [mastodon](https://github.com/mykdavies/Mastodon)
+* [dartodon](https://github.com/darkcl/dartodon)
 
 ## Elixir {#elixir}
 
 * [hunter](https://github.com/milmazz/hunter)
 
+## Erlang {#erlang}
+
+* [masterldon](https://github.com/igb/masterldon)
+
 ## Go {#go}
 
 * [go-mastodon](https://github.com/mattn/go-mastodon)
 * [madon](https://github.com/McKael/madon)
+* [go-mastodon-api](https://github.com/aaronland/go-mastodon-api)
 
 ## Haskell {#haskell}
 
@@ -50,10 +61,13 @@ menu:
 
 ## Java {#java}
 
-* [mastodon4j](https://github.com/sys1yagi/mastodon4j)
+* [BigBone](https://github.com/andregasser/bigbone)
+* [Mastodon4J](https://github.com/Mastodon4J/Mastodon4J)
+* [mastodon-jfx](https://github.com/wakingrufus/mastodon-jfx)
 
 ## JavaScript {#javascript}
 
+* [megalodon](https://github.com/h3poteto/megalodon)
 * [masto.js](https://github.com/neet/masto.js)
 * [libodonjs](https://github.com/Zatnosk/libodonjs)
 
@@ -63,8 +77,20 @@ menu:
 
 ## JavaScript (Node.js) {#javascript-node-js}
 
-* [node-mastodon](https://github.com/jessicahayley/node-mastodon)
 * [mastodon-api](https://github.com/vanita5/mastodon-api)
+
+## Kotlin {#kotlin}
+
+* [BigBone](https://github.com/andregasser/bigbone)
+* [mastodonk](https://github.com/outadoc/mastodonk)
+
+## Nim {#nim}
+
+* [Mastonim](https://github.com/matrix07012/Mastonim)
+
+## Objective-C {#objective-c}
+
+* [Cocotodon](https://github.com/shibafu528/Cocotodon)
 
 ## Perl {#perl}
 
@@ -72,20 +98,29 @@ menu:
 
 ## PHP {#php}
 
-* [Mastodon API for Laravel](https://github.com/kawax/laravel-mastodon-api)
-* [Composer based php API wrapper](https://github.com/r-daneelolivaw/mastodon-api-php)
-* [MastodonOAuthPHP](https://github.com/TheCodingCompany/MastodonOAuthPHP)
 * [Phediverse Mastodon REST Client](https://github.com/phediverse/mastodon-rest)
 * [TootoPHP](https://framagit.org/MaxKoder/TootoPHP)
 * [oauth2-mastodon](https://github.com/lrf141/oauth2-mastodon)
+* [MastodonBotPHP](https://github.com/Eleirbag89/MastodonBotPHP)
+* [mastodon-api-php-oauth](https://github.com/yks118/Mastodon-api-php-oauth)
+* [mastodon-api-php](https://github.com/colorfield/mastodon-api-php)
+* [Mastodon API for Laravel](https://github.com/kawax/laravel-mastodon-api)
+* [Mastodon for Drupal](https://github.com/colorfield/mastodon)
+* [Mastodon for Socialite](https://github.com/kawax/socialite-mastodon)
+
+## PowerShell {#powershell}
+
+* [Mastodon](https://github.com/JB405/Mastodon)
 
 ## Python {#python}
 
 * [Mastodon.py](https://github.com/halcy/Mastodon.py)
+* [mastopy](https://gitlab.com/spla/mastopy)
 
 ## R {#r}
 
 * [mastodon](https://github.com/ThomasChln/mastodon)
+* [rtoot](https://github.com/schochastics/rtoot)
 
 ## Ruby {#ruby}
 
@@ -93,8 +128,8 @@ menu:
 
 ## Rust {#rust}
 
-* [mammut](https://github.com/Aaronepower/mammut) (unmaintained)
-* [elefren](https://github.com/DeeUnderscore/elefren) (unmaintained)
+* [megalodon-rs](https://github.com/h3poteto/megalodon-rs)
+* [mastodon-async](https://github.com/dscottboggs/mastodon-async)
 
 ## Scala {#scala}
 
@@ -104,9 +139,17 @@ menu:
 
 ### Guile {#guile}
 
-* [elefan](https://codeberg.org/WammKD/Guile-Mastodon)
+* [Guile-Mastodon](https://codeberg.org/WammKD/Guile-Mastodon)
 
 ## Swift {#swift}
 
-* [MastodonKit](https://github.com/ornithocoder/MastodonKit)
+* [Mastodon.swift](https://github.com/Swiftodon/Mastodon.swift)
+* [MastodonKit](https://github.com/MastodonKit/MastodonKit)
+* [tootsdk](https://github.com/tootsdk/tootsdk)
+* [MastodonAPI](https://github.com/li-bei/MastodonAPI)
+
+## TypeScript {#typescript}
+
+* [tsl-mastodon](https://github.com/typescriptlibs/tsl-mastodon-api)
+
 

--- a/content/en/client/libraries.md
+++ b/content/en/client/libraries.md
@@ -29,6 +29,7 @@ Remember to check how recently the library was updated, and whether it includes 
 
 ## Common Lisp {#common-lisp}
 
+* [mastodon-cl](https://github.com/compufox/mastodon-cl)
 * [tooter](https://github.com/Shinmera/tooter)
 
 ## Crystal {#crystal}
@@ -38,6 +39,7 @@ Remember to check how recently the library was updated, and whether it includes 
 ## Dart
 
 * [mastodon-api](https://github.com/mastodon-dart/mastodon-api)
+* [mastodon-oauth](https://github.com/mastodon-dart/mastodon-oauth2)
 * [mastodon](https://github.com/mykdavies/Mastodon)
 * [dartodon](https://github.com/darkcl/dartodon)
 


### PR DESCRIPTION
Small addition to the README to note that this is currently a Hugo static site, for info only.

Main PR covers a large update to the libraries and implementations page:

- added a thank you to contributing projects and a CTA to let us know about updates and new libraries;
- removed outdated or archived projects, or seemingly inactive since ~2017/18 and behind on API methods;
- added large number of new projects 🎉 including new sections for IoT, Erlang, Kotlin, Nim, ObjC, TypeScript;
- updated links to projects that have moved.

Fixes #1204 fixes #1149 fixes #763 fixes #1160 

Built and tested locally with Hugo. In the future, the docs will be migrated to a different system; this PR brings this page up-to-date for the flurry of platform activity since start of 2023 in readiness for future improvements.

(note, aim to continue to review libraries for currency of support for the API over time)