### PR TITLE
Install guide fixes

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -190,7 +190,17 @@ cp /home/mastodon/live/dist/nginx.conf /etc/nginx/sites-available/mastodon
 ln -s /etc/nginx/sites-available/mastodon /etc/nginx/sites-enabled/mastodon
 ```
 
-Then edit `/etc/nginx/sites-available/mastodon` to replace `example.com` with your own domain name, and make any other adjustments you might need.
+Then edit `/etc/nginx/sites-available/mastodon` to 
+
+1. Replace `example.com` with your own domain name
+2. Uncomment the `ssl_certificate` and `ssl_certificate_key` lines and replace the two lines with (ignore this step if you are bringing your own certificate)
+
+```
+ssl_certificate     /etc/ssl/certs/ssl-cert-snakeoil.pem;
+ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
+```
+
+3. Make any other adjustments you might need.
 
 Reload nginx for the changes to take effect:
 

--- a/content/en/admin/optional/object-storage-proxy.md
+++ b/content/en/admin/optional/object-storage-proxy.md
@@ -19,6 +19,9 @@ server {
   server_name files.example.com;
   root /var/www/html;
 
+  ssl_certificate     /etc/ssl/certs/ssl-cert-snakeoil.pem;
+  ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
+
   keepalive_timeout 30;
 
   location = / {

--- a/content/zh-cn/admin/install.md
+++ b/content/zh-cn/admin/install.md
@@ -179,7 +179,17 @@ cp /home/mastodon/live/dist/nginx.conf /etc/nginx/sites-available/mastodon
 ln -s /etc/nginx/sites-available/mastodon /etc/nginx/sites-enabled/mastodon
 ```
 
-编辑 `/etc/nginx/sites-available/mastodon`，替换 `example.com` 为你自己的域名，你可以根据自己的需求做出其它的一些调整。
+编辑 `/etc/nginx/sites-available/mastodon`
+
+1. 替换 `example.com` 为你自己的域名
+2. 启用 `ssl_certificate` 和 `ssl_certificate_key` 这两行，并把它们替换成如下两行（如果你使用自己的证书的话则可以忽略这一步）
+
+```
+ssl_certificate     /etc/ssl/certs/ssl-cert-snakeoil.pem;
+ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
+```
+
+3. 你还可以根据自己的需求做出其它的一些调整。
 
 重载 nginx 以使变更生效：
 


### PR DESCRIPTION
Resolves https://github.com/mastodon/documentation/issues/857

This PR adds temporary ["snakeoil" certificates](https://wiki.debian.org/Self-Signed_Certificate) to the nginx configurations, in both mastodon installation guide & object storage proxy setup guide, so that the subsequent `systemctl reload nginx` wound run successfully. Without this change, the subsequent `systemctl reload nginx` command runs would fail with logs lines like

```
nginx: [emerg] no "ssl_certificate" is defined for the "listen ... ssl" directive in /etc/nginx/sites-enabled/mastodon:25
```

The "snakeoil" certificates would be replaced automatically by references to the real certificates once the `certbot --nginx -d domain` command is run. The command is present in both mastodon installation guide & object storage proxy setup guide

The linked issue also mentioned problems with `nodejs` and `yarn` installation but I tried the current documentation on a real VPS and it seems problems with those two software packages were already fixed.