### PR TITLE
Update Status method docs to include unauthenticated limits

### DIFF
--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -458,6 +458,7 @@ View statuses above and below this status in the thread.
 **OAuth:** Public for public statuses limited to 40 ancestors and 60 descendants with a maximum depth of 20. User token + `read:statuses` for up to 4,096 ancestors, 4,096 descendants, unlimited depth, and private statuses.\
 **Version history:**\
 0.0.0 - added
+4.0.0 - limit unauthenticated requests
 
 #### Request
 

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -455,7 +455,7 @@ GET /api/v1/statuses/:id/context HTTP/1.1
 View statuses above and below this status in the thread.
 
 **Returns:** [Context]({{< relref "entities/context" >}})\
-**OAuth:** Public for public statuses. User token + `read:statuses` for private statuses.\
+**OAuth:** Public for public statuses limited to 40 ancestors and 60 descendants with a maximum depth of 20. User token + `read:statuses` for up to 4,096 ancestors, 4,096 descendants, unlimited depth, and private statuses.\
 **Version history:**\
 0.0.0 - added
 


### PR DESCRIPTION
Not sure if this follows the correct style or is precisely where these limits should be noted, but the intent is to save others time by documenting these hardcoded limits:

https://github.com/mastodon/mastodon/blob/99be47f8b9a051fe409690ba157789958a587d12/app/controllers/api/v1/statuses_controller.rb#L21-L24

Related: https://github.com/mastodon/mastodon/issues/25892