### PR TITLE
More explicit wording for `pinned` param default

### DIFF
--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -767,7 +767,7 @@ exclude_reblogs
 : Boolean. Filter out boosts from the response.
 
 pinned
-: Boolean. Filter for pinned statuses only. Defaults to false, which excludes pinned statuses.
+: Boolean. Filter for pinned statuses only. Defaults to false, which includes all statuses. Pinned statuses do not receive special priority in the order of the returned results.
 
 tagged
 : String. Filter for statuses using a specific hashtag.

--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -767,7 +767,7 @@ exclude_reblogs
 : Boolean. Filter out boosts from the response.
 
 pinned
-: Boolean. Filter for pinned statuses only.
+: Boolean. Filter for pinned statuses only. Defaults to false, which excludes pinned statuses.
 
 tagged
 : String. Filter for statuses using a specific hashtag.


### PR DESCRIPTION
~~I incorrectly assumed that if I didn't include the `pinned` parameter, then I'd get both pinned and unpinned messages - i.e. I assumed that it defaulted to `undefined`, or whatever.~~

~~This small change makes it clear that you can either request all the unpinned messages (default), or all the pinned ones - i.e. there is no way to get both in one request (IIUC).~~

This change makes it explicit that pinned statuses do not receive special priority in the order of the returned results.