### PR TITLE
Clarify the documenation to reflect that 'description' on media attachments can be null

### DIFF
--- a/content/en/entities/MediaAttachment.md
+++ b/content/en/entities/MediaAttachment.md
@@ -212,7 +212,7 @@ More importantly, there may be another topl-level `focus` Hash object on images 
 ### `description` {#description}
 
 **Description:** Alternate text that describes what is in the media attachment, to be used for the visually impaired or when media attachments do not load.\
-**Type:** String\
+**Type:** {{<nullable>}} String, or null if alternate text was not provided for the media attachment\
 **Version history:**\
 2.0.0 - added
 


### PR DESCRIPTION
In my tests, media attachments for which no alternate text was provided are conveyed to the API client as having a null description. I'm not sure if this is intentional but assuming it is, this updates the documentation to properly reflect that. Another solution might be to ensure the description is always an empty string when no alternate text was provided.