### PR TITLE
content: Modify install tag checkout to avoid selecting beta releases

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -141,7 +141,7 @@ Use git to download the latest stable release of Mastodon:
 
 ```bash
 git clone https://github.com/mastodon/mastodon.git live && cd live
-git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)
+git checkout $(git tag -l | grep -v -P '(rc|beta)[0-9]*$' | sort -V | tail -n 1)
 ```
 
 #### Installing the last dependencies {#installing-the-last-dependencies}


### PR DESCRIPTION
## In short
* Modify `install.md`'s guidance to select a non-beta Git tag
  * Without this change, new users are guided to install Mastodon v4.2.0-beta1
  * Requires `grep` support for Perl regular expressions, already in Ubuntu

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Avoids guiding new Mastodon users to beta releases
Risk | ★☆☆ *1/3* | On other systems, `grep` may not support Perl regexp
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Details

The Mastodon installation guide avoids encouraging installing the release candidate (`rc`) builds of Mastodon, so it should probably avoid the beta (`beta`) builds as well.

The most [straightforward option is adding a capturing group, `(rc|beta)`](https://regex101.com/r/nAGAru/1 ).

Alternatively, to avoid Perl regular expressions, two `grep` commands could be chained together:

```sh
git tag -l | grep -v 'rc[0-9]*$' | grep -v 'beta[0-9]*$' | sort -V | tail -n 1
```

## Testing
### Steps
1.  Clone the Mastodon source code
```sh
# Enter a fresh directory
cd "$(mktemp -d)"
# Get code
git clone "https://github.com/mastodon/mastodon.git"
# Enter directory
cd "mastodon"
```

2.  Run the current tag selection command, observe output
```sh
git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1
```

3.  Run the new tag selection command, observe output
```sh
git tag -l | grep -v -P '(rc|beta)[0-9]*$' | sort -V | tail -n 1
```

### Results

The current command selects the current beta release:
```sh
v4.2.0-beta1
# git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1
```

The new command selects the latest stable release:
```sh
v4.1.6
# git tag -l | grep -v -P '(rc|beta)[0-9]*$' | sort -V | tail -n 1
```