### PR TITLE
README.md: fix logo for light/dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-![Mastodon](https://i.imgur.com/NhZc40l.png)
-====
+<h1><picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/mastodon/mastodon/raw/main/lib/assets/wordmark.dark.png?raw=true">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/mastodon/mastodon/raw/main/lib/assets/wordmark.light.png?raw=true">
+  <img alt="Mastodon" src="https://github.com/mastodon/mastodon/raw/mainlib/assets/wordmark.light.png?raw=true" height="34">
+</picture></h1>
 
 The documentation currently uses Hugo to generate a static site from Markdown.
 


### PR DESCRIPTION
Link to logo on GitHub instead of imgur
Use picture element for light/dark mode