### PR TITLE
Add hint about no e2e encryption

### DIFF
--- a/content/en/user/network.md
+++ b/content/en/user/network.md
@@ -84,6 +84,10 @@ The following operators are supported:
 
 In Mastodon, direct messages are just posts that have the "direct" visibility selected. Visibility can be selected per-post, which allows changing the privacy level later in a thread. The direct messages column currently shows a list of all conversations containing a direct post. Clicking on a conversation will load the associated thread.
 
+{{< hint style="danger" >}}
+Please note that Mastodon currently **does not support end-to-end encryption** for direct messages. This means that any direct messages you send may not be fully protected from outside views. End-to-end encryption is planned, but not yet implemented into Mastodon.
+{{< /hint >}}
+
 {{< figure src="assets/dm-thread.jpg" caption="A direct message in a thread." >}}
 
 ## List timelines {#lists}


### PR DESCRIPTION
Mastodon does not yet support End-to-end encryption.

However, looking at the "Using the network features" page is this not mentioned anywhere within the direct messages section.
At most is there the small hint, that a direct message is just a post with a changed setting.

This is bad, as it doesn't tell the user, that the messages don't have any guaranteed protection against someone obtaining (and more importantly reading) their messages.

Of course someone can argue that mastodon has the note about no e2e encryption whenever you select the direct type, but this relies on using the Mastodon web-app (And I assume phone app), since 3rd-party services may not have such an important hint anywhere...
Also, if a user first reads the docs before using it in Mastodon itself should it be a good idea to inform them early.

On another, unrelated note was I also considering to add a note regarding mentioned users being added to a discussion, even if it wasn't the user's intent, as that too could be crucial information the user may want to know first. After all do you not want to share personal info in regards to someone knowing that they would be able to see it too because you mentioned them, right?
Either way, I decided to leave this PR focused on the e2e notice as this was a more important thing to mention. The other thing could still be added later on in another PR or commit.