### PR TITLE
Change tootctl search deploy default batch size to 100 to match reality

### DIFF
--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -807,7 +807,7 @@ Remove local thumbnails for preview cards.
 Create or update an Elasticsearch index and populate it. If Elasticsearch is empty, this command will create the necessary indices and then import data from the database into those indices. This command will also upgrade indices if the underlying schema has been changed since the last run.
 
 `--batch-size`
-: Defaults to 1000. A lower batch size can make ElasticSearch process records more quickly.
+: Defaults to 100. A higher batch size can make ElasticSearch process records more quickly, with less load on the PostgreSQL database, but consumes more resources on the system running this command.
 
 `--only INDEX`
 : Specify an index name [`accounts`, `tags`, `statuses`] to create or update only that index.

--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -807,7 +807,7 @@ Remove local thumbnails for preview cards.
 Create or update an Elasticsearch index and populate it. If Elasticsearch is empty, this command will create the necessary indices and then import data from the database into those indices. This command will also upgrade indices if the underlying schema has been changed since the last run.
 
 `--batch-size`
-: Defaults to 100. A higher batch size can make Elasticsearch process records more quickly, with less load on the PostgreSQL database, but can increase memory pressure on the Elasticsearch nodes during indexing and consumes more resources on the system running this command.
+: Defaults to 100. A higher batch size can make Elasticsearch process records more quickly, with less load on the PostgreSQL database, but can increase memory pressure on the Elasticsearch nodes during indexing.
 
 `--only INDEX`
 : Specify an index name [`accounts`, `tags`, `statuses`] to create or update only that index.

--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -807,7 +807,7 @@ Remove local thumbnails for preview cards.
 Create or update an Elasticsearch index and populate it. If Elasticsearch is empty, this command will create the necessary indices and then import data from the database into those indices. This command will also upgrade indices if the underlying schema has been changed since the last run.
 
 `--batch-size`
-: Defaults to 100. A higher batch size can make ElasticSearch process records more quickly, with less load on the PostgreSQL database, but consumes more resources on the system running this command.
+: Defaults to 100. A higher batch size can make Elasticsearch process records more quickly, with less load on the PostgreSQL database, but can increase memory pressure on the Elasticsearch nodes during indexing and consumes more resources on the system running this command.
 
 `--only INDEX`
 : Specify an index name [`accounts`, `tags`, `statuses`] to create or update only that index.


### PR DESCRIPTION
The defaults for `tootctl search deploy` batch size is actually 100, and increasing this size is what makes performance faster with lower database impact.