### PR TITLE
Update Node.js 16.x installation documentation

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -26,7 +26,14 @@ apt install -y curl wget gnupg apt-transport-https lsb-release ca-certificates
 #### Node.js {#node-js}
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_16.x | bash -
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+NODE_MAJOR=16
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+sudo apt-get update
+sudo apt-get install nodejs -y
 ```
 
 #### PostgreSQL {#postgresql}


### PR DESCRIPTION
Upon using the Node.js 16 installation script, I receive a warning that the script is deprecated.

![Screenshot_20230916_142917](https://github.com/mastodon/documentation/assets/814940/f5f06180-5443-4f08-9fbe-e09e9ab6ac05)

I've amended the documentation to follow the steps listed in the [nodesource/distributions Installation Instructions](https://github.com/nodesource/distributions#installation-instructions).
