### PR TITLE
Fix ES sample config with no auth is user

### DIFF
--- a/content/en/admin/elasticsearch.md
+++ b/content/en/admin/elasticsearch.md
@@ -1,6 +1,8 @@
 ---
 title: Configuring full-text search
 description: Setting up Elasticsearch to search for statuses (authored, favourited, or mentioned), public indexable status, and accounts
+aliases:
+- /admin/optional/elasticsearch
 menu:
   docs:
     weight: 40

--- a/content/en/admin/elasticsearch.md
+++ b/content/en/admin/elasticsearch.md
@@ -67,8 +67,8 @@ ES_ENABLED=true
 ES_HOST=localhost
 ES_PORT=9200
 ES_PRESET= # single_node_cluster, small_cluster or large_cluster
-ES_USER=
-ES_PASS=
+# ES_USER=
+# ES_PASS=
 ```
 
 ### Choosing the correct preset


### PR DESCRIPTION
`ES_USER` and `ES_PASS` need to be undefined when no auth should be used, other wise it uses `:` for credentials