### PR TITLE
Fix typo and capitalization

### DIFF
--- a/content/en/admin/elasticsearch.md
+++ b/content/en/admin/elasticsearch.md
@@ -24,7 +24,7 @@ It deliberately does not allow searching for arbitrary strings in the entire dat
 ## Installing Elasticsearch {#install}
 
 {{< hint style="info" >}}
-Mastodon is tested with ElasticSearch version 7. It should support OpenSearch, as well as ElectisSearch versions 6 and 8, but those setups are not officially supported.
+Mastodon is tested with Elasticsearch version 7. It should support OpenSearch, as well as Elasticsearch versions 6 and 8, but those setups are not officially supported.
 {{< /hint >}}
 
 Elasticsearch requires a Java runtime. If you don’t have Java already installed, do it now. Assuming you are logged in as `root`:


### PR DESCRIPTION
I figure it should be either `Elasticsearch` or `ElasticSearch`, consistently, but not `ElectisSearch` :)