### PR TITLE
fix incorrect example for last_status_at

### DIFF
--- a/content/en/entities/Account.md
+++ b/content/en/entities/Account.md
@@ -48,7 +48,7 @@ aliases: [
   "followers_count": 547,
   "following_count": 404,
   "statuses_count": 28468,
-  "last_status_at": "2019-11-17T00:02:23.693Z",
+  "last_status_at": "2019-11-17",
   "emojis": [
     {
       "shortcode": "ms_rainbow_flag",


### PR DESCRIPTION
this api returns just the date, no time component

fix https://github.com/mastodon/mastodon/issues/26843
