### PR TITLE
Update the end point url on emails.md

### DIFF
--- a/content/en/methods/emails.md
+++ b/content/en/methods/emails.md
@@ -21,7 +21,7 @@ aliases: [
 ## Resend confirmation email {#confirmation}
 
 ```http
-POST /api/v1/emails/confirmation HTTP/1.1
+POST /api/v1/emails/confirmations HTTP/1.1
 ```
 
 **Returns:** Empty object\


### PR DESCRIPTION
/api/v1/emails/confirmation should be /api/v1/emails/confirmations (with an ending s) otherwise a 404 is returned