### PR TITLE
Add documentation for VAPID public key in instance metadata

### DIFF
--- a/content/en/entities/Application.md
+++ b/content/en/entities/Application.md
@@ -39,13 +39,6 @@ aliases: [
 0.9.9 - added\
 3.5.1 - this property is now nullable
 
-### `vapid_key` {#vapid_key}
-
-**Description:** Used for Push Streaming API. Returned with [POST /api/v1/apps]({{< relref "methods/apps#create" >}}). Equivalent to [WebPushSubscription#server_key]({{< relref "entities/WebPushSubscription#server_key" >}})\
-**Type:** String\
-**Version history:**\
-2.8.0 - added
-
 ### `client_id` {{%optional%}} {#client_id}
 
 **Description:** Client ID key, to be used for obtaining OAuth tokens\
@@ -59,6 +52,16 @@ aliases: [
 **Type:** String\
 **Version history:**\
 0.9.9 - added
+
+## Deprecated attributes
+
+### `vapid_key` {#vapid_key}
+
+**Description:** Used for Push Streaming API. Returned with [POST /api/v1/apps]({{< relref "methods/apps#create" >}}). Equivalent to [WebPushSubscription#server_key]({{< relref "entities/WebPushSubscription#server_key" >}}) and [Instance#vapid_public_key]({{< relref "entities/Instance#vapid_public_key" >}})\
+**Type:** String\
+**Version history:**\
+2.8.0 - added
+4.3.0 - deprecated pending removal
 
 ## See also
 

--- a/content/en/entities/Instance.md
+++ b/content/en/entities/Instance.md
@@ -41,6 +41,9 @@ aliases: [
     "urls": {
       "streaming": "wss://mastodon.social"
     },
+    "vapid": {
+      "public_key": "BCkMmVdKDnKYwzVCDC99Iuc9GvId-x7-kKtuHnLgfF98ENiZp_aj-UNthbCdI70DqN1zUVis-x0Wrot2sBagkMc="
+    },
     "accounts": {
       "max_featured_tags": 10
     },
@@ -289,6 +292,12 @@ aliases: [
 **Type:** String (URL)\
 **Version history:**\
 4.0.0 - added
+
+### `configuration[vapid][public_key]` (#vapid_public_key)
+**Description:** The instances VAPID public key, used for push notifications, the same as [WebPushSubscription#server_key]({{< relref "entities/WebPushSubscription#server_key" >}}).\
+**Type:** String\
+**Version history:**\
+4.3.0 - added
 
 #### `configuration[accounts]` {#accounts}
 

--- a/content/en/methods/instance.md
+++ b/content/en/methods/instance.md
@@ -61,6 +61,9 @@ Obtain general information about the server.
     "urls": {
       "streaming": "wss://mastodon.social"
     },
+    "vapid": {
+      "public_key": "BCkMmVdKDnKYwzVCDC99Iuc9GvId-x7-kKtuHnLgfF98ENiZp_aj-UNthbCdI70DqN1zUVis-x0Wrot2sBagkMc="
+    },
     "accounts": {
       "max_featured_tags": 10
     },


### PR DESCRIPTION
As per: https://github.com/mastodon/mastodon/pull/28006/