### PR TITLE
Add explanation for S3 batch delete variables

### DIFF
--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -548,6 +548,14 @@ You must serve the files with CORS headers, otherwise some functions of Mastodon
 
 #### `S3_FORCE_SINGLE_REQUEST`
 
+#### `S3_BATCH_DELETE_LIMIT`
+
+The official [Amazon S3 API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html) can handle deleting 1,000 objects in one batch job, but some providers may have issues handling this many in one request, or offer lower limits. Defaults to `1000`.
+
+#### `S3_BATCH_DELETE_RETRY`
+
+During batch delete operations, S3 providers may perodically fail or timeout while processing deletion requests. Mastodon will backoff and retry the request up to the maximum number of times. Defaults to `3`.
+
 ### Swift {#swift}
 
 #### `SWIFT_ENABLED`

--- a/content/zh-cn/admin/config.md
+++ b/content/zh-cn/admin/config.md
@@ -148,6 +148,8 @@ Mastodon使用环境变量作为其的配置。
 * `S3_HOSTNAME`
 * `S3_ENDPOINT`
 * `S3_SIGNATURE_VERSION`
+* `S3_BATCH_DELETE_LIMIT`
+* `S3_BATCH_DELETE_RETRY`
 
 ### Swift {#swift}
 


### PR DESCRIPTION
These variables are added in https://github.com/mastodon/mastodon/pull/28184 to control media batch deletion retry operations.