### PR TITLE
fix fail2ban sshd setup in jail.local

### DIFF
--- a/content/en/admin/prerequisites.md
+++ b/content/en/admin/prerequisites.md
@@ -42,11 +42,7 @@ sendername = Fail2Ban
 [sshd]
 enabled = true
 port = 22
-
-[sshd-ddos]
-enabled = true
-filter = sshd
-port = 22
+mode = aggressive
 ```
 
 Finally, restart fail2ban:


### PR DESCRIPTION
Fixes https://github.com/mastodon/documentation/issues/943 (again)

The previous PR https://github.com/mastodon/documentation/pull/969 for this setting does remove the error message, but it does so by duplicating the default sshd jail a second time with a different name, and does not enable the ddos filters as intended.

Only a single jail is needed, this PR specifies the `aggressive` mode, which includes the default filters, plus 'extra' and 'ddos' filters, per the instructions in the fail2ban config files:
```
# To use more aggressive sshd modes set filter parameter "mode" in jail.local:
# normal (default), ddos, extra or aggressive (combines all).
# See "tests/files/logs/sshd" or "filter.d/sshd.conf" for usage example and details.
#mode   = normal
```
```
# Parameter "mode": normal (default), ddos, extra or aggressive (combines all)
# Usage example (for jail.local):
#   [sshd]
#   mode = extra
```