### PR TITLE
Removed unused (not implemented) query parameter.

### DIFF
--- a/content/en/methods/announcements.md
+++ b/content/en/methods/announcements.md
@@ -38,11 +38,6 @@ See all currently active announcements set by admins.
 Authorization
 : {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
 
-##### Query parameters
-
-with_dismissed
-: Boolean. If true, response will include announcements dismissed by the user. Defaults to false.
-
 #### Response
 ##### 200: OK
 


### PR DESCRIPTION
Per https://github.com/mastodon/mastodon/issues/27310, the `with_dismissed` parameter on the announcements API is not actually implemented and is ignored.

Closes #1317 