### PR TITLE
Revert "Add basic Redis Sentinel documentation"

### DIFF
--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -369,42 +369,6 @@ Defaults to the value of `REDIS_NAMESPACE`.
 
 #### `SIDEKIQ_REDIS_URL`
 
-#### `REDIS_SENTINEL`
-
-Either a single DNS name that resolves one or more A records for [Redis Sentinel](https://redis.io/docs/management/sentinel/), or a comma-delimited list of Redis Sentinel instance IP:PORTs.
-
-#### `REDIS_SENTINEL_MASTER`
-
-The name of the Redis Sentinel master to connect to, defaults to `mymaster`.
-
-#### `REDIS_SENTINEL_PORT`
-
-If using the DNS name approach for `REDIS_SIDEKIQ_SENTINEL`, defines the port to use to connect to the instances resolved. Defaults to `26379`.
-
-#### `CACHE_REDIS_SENTINEL`
-
-Either a single DNS name that resolves one or more A records for [Redis Sentinel](https://redis.io/docs/management/sentinel/), or a comma-delimited list of Redis Sentinel instance IP:PORTs.
-
-#### `CACHE_REDIS_SENTINEL_MASTER`
-
-The name of the Redis Sentinel master to connect to, defaults to `mymaster`.
-
-#### `CACHE_REDIS_SENTINEL_PORT`
-
-If using the DNS name approach for `CACHE_REDIS_SENTINEL`, defines the port to use to connect to the instances resolved. Defaults to `26379`.
-
-#### `SIDEKIQ_REDIS_SENTINEL`
-
-Either a single DNS name that resolves one or more A records for [Redis Sentinel](https://redis.io/docs/management/sentinel/), or a comma-delimited list of Redis Sentinel instance IP:PORTs.
-
-#### `SIDEKIQ_REDIS_SENTINEL_MASTER`
-
-The name of the Redis Sentinel master to connect to, defaults to `mymaster`.
-
-#### `SIDEKIQ_REDIS_SENTINEL_PORT`
-
-If using the DNS name approach for `SIDEKIQ_REDIS_SENTINEL`, defines the port to use to connect to the instances resolved. Defaults to `26379`.
-
 ### Elasticsearch {#elasticsearch}
 
 {{< page-ref page="admin/elasticsearch" >}}

--- a/content/en/admin/scaling.md
+++ b/content/en/admin/scaling.md
@@ -373,11 +373,6 @@ systemctl restart mastodon-web.service
 systemctl restart redis-sidekiq.service
 ```
 
-
-## Redis Sentinel for High Availability {#redis-sentinel}
-
-As mentioned, Redis is a critical part of a Mastodon instance's operation. By default, your deployment will use a single Redis instance, or multiple if you've setup a cache. However if that instance goes down it can bring the entire Mastodon instance down as well. To alleviate this, Redis Sentinel can be used to track your Redis instances and automatically direct clients to a new primary if one goes down. You can specify `REDIS_SENTINEL`, which is either a DNS name that resolves to the IPs of your Redis Sentinel instances (e.g a Kubernetes service) or a comma-delimited list of the IP:Port combinations directly, that Mastodon can talk with to determine the current master Redis node. By default Sentinel will set an instance as down and select a new master after a minute of the current master being unreachable, but this can be configured based on your setup.
-
 ## Read-replicas {#read-replicas}
 
 To reduce the load on your PostgreSQL server, you may wish to set up hot streaming replication (read replica). [See this guide for an example](https://cloud.google.com/community/tutorials/setting-up-postgres-hot-standby). You can make use of the replica in Mastodon in these ways:


### PR DESCRIPTION
Reverts mastodon/documentation#1311 as this has not been merged in the code yet.