### PR TITLE
Fix issue with VAPID Public Key linking in Instance.md

### DIFF
--- a/content/en/entities/Instance.md
+++ b/content/en/entities/Instance.md
@@ -293,7 +293,7 @@ aliases: [
 **Version history:**\
 4.0.0 - added
 
-### `configuration[vapid][public_key]` (#vapid_public_key)
+### `configuration[vapid][public_key]` {#vapid_public_key}
 **Description:** The instances VAPID public key, used for push notifications, the same as [WebPushSubscription#server_key]({{< relref "entities/WebPushSubscription#server_key" >}}).\
 **Type:** String\
 **Version history:**\


### PR DESCRIPTION
I'd accidentally used brackets instead of curly braces in the original PR #1342
<img width="775" alt="Screenshot 2023-12-18 at 19 09 50" src="https://github.com/mastodon/documentation/assets/30827/a73f5b7b-33e3-4bcf-b2ca-dc0265dc5c94">
