### PR TITLE
Remove "required" label from no-longer-required methods

### DIFF
--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -858,7 +858,7 @@ Accounts which follow the given account, if network is not hidden by the account
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -964,7 +964,7 @@ Accounts which the given account is following, if network is not hidden by the a
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
 
 ##### Query parameters
 


### PR DESCRIPTION
getting an account's followers/following was changed to not require auth in v4.0, but the "required" label was still present on the Authorization header