### PR TITLE
Fix token type in account creation.

### DIFF
--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -37,7 +37,7 @@ Creates a user and account records. Returns an account access token for the app 
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <app token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 


### PR DESCRIPTION
The 'OAuth' field for the create-account request says that it wants an _app_ token. But the description of the 'Authorization' header says a user token.

Surely the app token is right, because if you haven't created an account yet, you don't _have_ a user token.