### PR TITLE
Add clarification for `domain`/`uri` in API `Instance` response

### DIFF
--- a/content/en/entities/Instance.md
+++ b/content/en/entities/Instance.md
@@ -169,7 +169,7 @@ aliases: [
 
 ### `domain` {#domain}
 
-**Description:** The domain name of the instance.\
+**Description:** The domain name of the instance. Corresponds to the configured `LOCAL_DOMAIN`, which is used for account handles, and is not necessarily the same as `WEB_DOMAIN` where the Mastodon API and web interface are hosted.\
 **Type:** String\
 **Version history:**\
 4.0.0 - added

--- a/content/en/entities/V1_Instance.md
+++ b/content/en/entities/V1_Instance.md
@@ -148,7 +148,7 @@ aliases: [
 
 ### `uri` {#uri}
 
-**Description:** The domain name of the instance.\
+**Description:** The domain name of the instance. Corresponds to the configured `LOCAL_DOMAIN`, which is used for account handles, and is not necessarily the same as `WEB_DOMAIN` where the Mastodon API and web interface are hosted.\
 **Type:** String\
 **Version history:**\
 1.1.0 - added


### PR DESCRIPTION
Since `LOCAL_DOMAIN` and `WEB_DOMAIN` can be separate, as an API user I needed to be aware of the distinction when using this property.