### PR TITLE
Fix incorrect property name `streaming_api` for the `Instance` entity

### DIFF
--- a/content/en/entities/Instance.md
+++ b/content/en/entities/Instance.md
@@ -286,7 +286,7 @@ aliases: [
 **Version history:**\
 4.0.0 - added
 
-##### `configuration[urls][streaming_api]` {#streaming_api}
+##### `configuration[urls][streaming]` {#streaming}
 
 **Description:** The Websockets URL for connecting to the streaming API.\
 **Type:** String (URL)\


### PR DESCRIPTION
The entity used for `/api/v2/instance` returns the streaming URL as `streaming`, not `streaming_api`.