### PR TITLE
Update documentation with Home feed visibility for replies

### DIFF
--- a/content/en/user/posting.md
+++ b/content/en/user/posting.md
@@ -125,6 +125,17 @@ Send your post only to mentioned users.
 **Do not share dangerous and sensitive information over direct messages**. Mastodon is not an encrypted messaging app like Signal or Wire, the database administrators of the sender’s and recipient’s servers have access to the text. Use them with the same caution as you would use forum PMs, Discord PMs and Twitter DMs.
 {{< /hint >}}
 
+## Home feed visibility for replies
+
+Your replies will only appear on your followers' Home feeds if they follow both you and the person you're replying to. 
+
+Some notes about this:
+
+* A new post you make which starts with an `@mention` is **not** considered a reply, so it will show up on the Home feed of all your followers.
+* The reply's visibility (Public vs Unlisted vs Followers-Only) does **not** affect whether it shows up on the Home feed
+* If your post is public and contains a followed hashtag, it'll be shown on the Home feed regardless of whether it's a reply
+* Other Fediverse software may show all of your replies on the Home feed, no matter who the posts are replies to
+
 ## Content warnings and sensitive content {#cw}
 
 {{< figure src="assets/status-cw.jpg" caption="A status with a CW that is marked as sensitive content." >}}

--- a/content/en/user/posting.md
+++ b/content/en/user/posting.md
@@ -127,14 +127,14 @@ Send your post only to mentioned users.
 
 ## Home feed visibility for replies
 
-Your replies will only appear on your followers' Home feeds if they follow both you and the person you're replying to. 
+Your replies will only appear on your followers' Home feeds if they follow both you and the person you are replying to.
 
 Some notes about this:
 
 * A new post you make which starts with an `@mention` is **not** considered a reply, so it will show up on the Home feed of all your followers.
-* The reply's visibility (Public vs Unlisted vs Followers-Only) does **not** affect whether it shows up on the Home feed
-* If your post is public and contains a followed hashtag, it'll be shown on the Home feed regardless of whether it's a reply
-* Other Fediverse software may show all of your replies on the Home feed, no matter who the posts are replies to
+* The reply's visibility (Public vs Unlisted vs Followers-Only) does **not** affect whether it shows up on the Home feed.
+* If your post is public and contains a followed hashtag, it will be shown on the Home feed regardless of whether it is a reply.
+* Other Fediverse software may show all of your replies on the Home feed, no matter who the posts are replies to.
 
 ## Content warnings and sensitive content {#cw}
 


### PR DESCRIPTION
I couldn't find any documentation of under what condition my replies are shown in my followers' Home feeds and I noticed a lot of other people are confused about this as well (cf [this post & its replies](https://social.jvns.ca/@b0rk/111890684193270196#.)), so here's a documentation update that explains how it works.

The 3 specific things that I found the most confusing were:

1. A new post you make which starts with an `@mention` is **not** considered a reply (unlike how it works on Twitter)
2. Some other Fediverse software (like maybe Pleroma) will show all your replies on the Home timeline, regardless of whether the follower follows both of the people in the conversation
3. I've often heard that if you want your replies to not be shown on the Home timeline, you need to post them as Unlisted instead of Public. I'm pretty sure that this isn't true (??), but if not it seems like a very common belief.

cc @ClearlyClaire who explained this to me on Mastodon. Please let me know if I got any of this wrong, or if you think it would be better documented somewhere else.