### PR TITLE
Add documentation for setting up captcha's

### DIFF
--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -848,6 +848,20 @@ This setting has no relation to which users are considered active for the purpos
 
 This variable only has any effect when running `rake db:migrate` and it is extremely specific to the Mastodon upgrade process. There are two types of database migrations, those that run before new code is deployed and running, and those that run after. By default, both types of migrations are executed. If you shut down all Mastodon processes before running migrations, then there is no difference. The variable makes sense for zero-downtime upgrades. You will see in the upgrade instructions of a specific Mastodon version if you need to use it or not.
 
+### Sign-up Captcha {#captcha}
+
+Setting these variables will allow for hCaptcha support on sign-up.
+
+Defaults to empty values (not enabled)
+
+{{< hint style="info" >}}
+If you wish to use hCaptcha, don't forget to enable it from the Administration -> Dashboard page after configuring.
+{{</ hint >}}
+
+#### `HCAPTCHA_SITE_KEY`
+
+#### `HCAPTCHA_SECRET_KEY`
+
 ### Uncategorized or unsorted
 
 #### `BUNDLE_GEMFILE`
@@ -869,12 +883,6 @@ Defaults to `mastodon/mastodon`
 Defaults to `https://github.com/$GITHUB_REPOSITORY`
 
 #### `FFMPEG_BINARY`
-
-#### `HCAPTCHA_SITE_KEY`
-
-Set this to your hCaptcha site key to enable captchas on the account confirmation page using hCaptcha.
-
-Defaults to empty value (not enabled)
 
 #### `LOCAL_HTTPS`
 

--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -855,7 +855,7 @@ Setting these variables will allow for hCaptcha support on sign-up.
 Defaults to empty values (not enabled)
 
 {{< hint style="info" >}}
-If you wish to use hCaptcha, don't forget to enable it from the Administration -> Dashboard page after configuring.
+If you wish to use hCaptcha, don't forget to enable it from the Administration -> Server Settings page after configuring.
 {{</ hint >}}
 
 #### `HCAPTCHA_SITE_KEY`

--- a/content/zh-cn/admin/config.md
+++ b/content/zh-cn/admin/config.md
@@ -52,7 +52,7 @@ Mastodon使用环境变量作为其的配置。
 
 ### 部署 {#deployment}
 
-* `RAILS_ENV`
+* `RAILS_ENV` 
 * `RAILS_SERVE_STATIC_FILES`
 * `RAILS_LOG_LEVEL`
 * `TRUSTED_PROXY_IP`
@@ -243,5 +243,7 @@ Mastodon使用环境变量作为其的配置。
 ## 其它 {#other}
 
 * `SKIP_POST_DEPLOYMENT_MIGRATIONS`
+* `HCAPTCHA_SITE_KEY`
+* `HCAPTCHA_SECRET_KEY`
 
 {{< translation-status-zh-cn raw_title="Configuring your environment" raw_link="/admin/config/" last_tranlation_time="2020-05-04" raw_commit="ad1ef20f171c9f61439f32168987b0b4f9abd74b">}}

--- a/content/zh-cn/admin/config.md
+++ b/content/zh-cn/admin/config.md
@@ -52,7 +52,7 @@ Mastodon使用环境变量作为其的配置。
 
 ### 部署 {#deployment}
 
-* `RAILS_ENV` 
+* `RAILS_ENV`
 * `RAILS_SERVE_STATIC_FILES`
 * `RAILS_LOG_LEVEL`
 * `TRUSTED_PROXY_IP`


### PR DESCRIPTION
In light of the recent spam wave, I was surprised to find out there barely is any documentation of this (it doesn't even mention the HCAPTCHA_SECRET_KEY)

Small modification to clear things up :)