### PR TITLE
Added clarification about blind/low-vision people to captcha.md

### DIFF
--- a/content/en/admin/optional/captcha.md
+++ b/content/en/admin/optional/captcha.md
@@ -14,7 +14,7 @@ With CAPTCHA enabled, new registrations will be required to complete a challenge
 
 {{< hint style="danger" >}}
 For some people, the use of a central CAPTCHA service may be a security and privacy concern.
-In addition, CAPTCHA can make the registration process significantly less accessible to some people.
+In addition, CAPTCHA can make the registration process significantly less accessible, particularly for individuals with visual impairments, such as those who are blind or have low vision.
 {{</ hint >}}
 
 Currently, hCaptcha is the only available provider supported by Mastodon.


### PR DESCRIPTION
The original text didn't exactly make it clear to what kind of people the use of hcaptcha was problematic