### PR TITLE
Improve hCaptcha site key and secret key description

### DIFF
--- a/content/en/admin/optional/captcha.md
+++ b/content/en/admin/optional/captcha.md
@@ -23,7 +23,8 @@ Other providers may be added in the future.
 ## hCaptcha
 
 - Create a free hCaptcha account at [hcaptcha.com](https://www.hcaptcha.com)
-- After completing registration, generate a Site Key and Site Secret from the hCaptcha dashboard
+- After completing registration, use the hCaptcha dashboard to add a new site with your domain to obtain a Site Key
+- From the Account Settings menu in hCaptcha, obtain your Secret Key
 - Add the values to your Mastodon environment configuration as `HCAPTCHA_SITE_KEY` and `HCAPTCHA_SECRET_KEY`
 - Restart the Mastodon services running on your server
 - From the Mastodon web interface navigate to **Administration**  > **Server settings** > **Registrations** and check the box labled "Require new users to solve a CAPTCHA to confirm their account"


### PR DESCRIPTION
Had some feedback that the directions to obtain the site key and secret key were not as clear as they could be, this breaks them into two items with a direction of where to find the secret key.