### PR TITLE
Fix docs of the Translation entity

### DIFF
--- a/content/en/entities/Translation.md
+++ b/content/en/entities/Translation.md
@@ -79,7 +79,7 @@ Translation of status with poll:
 ### `media_attachments` {#media_attachments}
 
 **Description:** The translated media descriptions of the status.\
-**Type:** Array\
+**Type:** Array of [Translation::Attachment](#Attachment)\
 **Version history:**\
 4.2.0 - added
 
@@ -101,7 +101,7 @@ Translation of status with poll:
 
 ### `id` {#Poll-id}
 
-**Description:** The ID of the Poll.\
+**Description:** The ID of the poll.\
 **Type:** String (cast from an integer, but not guaranteed to be a number)\
 **Version history:**\
 4.2.0 - added
@@ -109,7 +109,32 @@ Translation of status with poll:
 ### `options` {#Poll-options}
 
 **Description:** The translated poll options.\
-**Type:** Array\
+**Type:** Array of [Translation::Poll::Option](#Option)\
+**Version history:**\
+4.2.0 - added
+
+## Translation::Poll::Option attributes {#Option}
+
+### `title` {#Option-title}
+
+**Description:** The translated title of the poll option.\
+**Type:** String\
+**Version history:**\
+4.2.0 - added
+
+## Translation::Attachment attributes {#Attachment}
+
+### `id` {#Attachment-id}
+
+**Description:** The id of the attachment.\
+**Type:** String (cast from an integer, but not guaranteed to be a number)\
+**Version history:**\
+4.2.0 - added
+
+### `description` {#Attachment-description}
+
+**Description:** The translated description of the attachment.\
+**Type:** String\
 **Version history:**\
 4.2.0 - added
 

--- a/content/en/entities/Translation.md
+++ b/content/en/entities/Translation.md
@@ -20,7 +20,7 @@ Translation of status with content warning and media
   "spoiler_text": "Greatings ahead",
   "media_attachments": [
     {
-      "id": 22345792,
+      "id": "22345792",
       "description": "Status author waving at the camera"
     }
   ],
@@ -36,19 +36,17 @@ Translation of status with poll:
   "content": "<p>Should I stay or should I go?</p>",
   "spoiler_text": "",
   "media_attachments": [],
-  "poll": [
-    {
-      "id": 34858,
-      "options": [
-        {
-          "title": "Stay" 
-        },
-        {
-          "title": "Go"
-        }
-      ]
-    }
-  ],
+  "poll": {
+    "id": "34858",
+    "options": [
+      {
+        "title": "Stay" 
+      },
+      {
+        "title": "Go"
+      }
+    ]
+  },
   "detected_source_language": "ja",
   "provider": "DeepL.com"
 }
@@ -73,8 +71,8 @@ Translation of status with poll:
 
 ### `poll` {#poll}
 
-**Description:** The translated poll options of the status.\
-**Type:** Array\
+**Description:** The translated poll of the status.\
+**Type:** [Translation::Poll](#Poll)\
 **Version history:**\
 4.2.0 - added
 
@@ -98,6 +96,22 @@ Translation of status with poll:
 **Type:** String\
 **Version history:**\
 4.0.0 - added
+
+## Translation::Poll attributes {#Poll}
+
+### `id` {#Poll-id}
+
+**Description:** The ID of the Poll.\
+**Type:** String (cast from an integer, but not guaranteed to be a number)\
+**Version history:**\
+4.2.0 - added
+
+### `options` {#Poll-options}
+
+**Description:** The translated poll options.\
+**Type:** Array\
+**Version history:**\
+4.2.0 - added
 
 ## See also
 

--- a/content/en/entities/Translation.md
+++ b/content/en/entities/Translation.md
@@ -62,14 +62,14 @@ Translation of status with poll:
 **Version history:**\
 4.0.0 - added
 
-### `spoiler_warning` {#spoiler_warning}
+### `spoiler_text` {#spoiler_text}
 
 **Description:** The translated spoiler warning of the status.\
 **Type:** String\
 **Version history:**\
 4.2.0 - added
 
-### `poll` {#poll}
+### `poll` {{%optional%}} {#poll}
 
 **Description:** The translated poll of the status.\
 **Type:** [Translation::Poll](#Poll)\


### PR DESCRIPTION
The `poll` attribute is an object, not an array, and is optional.
`id`s are strings, not integers.
The attribute is called `spoiler_text` and not `spoiler_warning`.