### PR TITLE
Use `.Path` instead of `.File.Path` when surrounded by `with .File` block

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -35,5 +35,5 @@
     <a href='https://joinmastodon.org'>{{ i18n "joinMastodon" }}</a> · <a href='https://blog.joinmastodon.org'>{{ i18n "blog" }}</a> · <a href='https://mastodon.social/@Mastodon' target='_blank'><i class='fab fa-mastodon'></i></a>
   </p>
 
-  <p class="legal">{{ with .File }}<a href='https://github.com/mastodon/documentation/tree/main/content/{{ .Lang }}/{{ .File.Path }}'>{{ i18n "viewSource" }}</a> · {{ end }}<a href='https://creativecommons.org/licenses/by-sa/4.0/'>CC BY-SA 4.0</a> · <a href='https://joinmastodon.org/imprint'>{{ i18n "imprint" }}</a></p>
+  <p class="legal">{{ with .File }}<a href='https://github.com/mastodon/documentation/tree/main/content/{{ .Lang }}/{{ .Path }}'>{{ i18n "viewSource" }}</a> · {{ end }}<a href='https://creativecommons.org/licenses/by-sa/4.0/'>CC BY-SA 4.0</a> · <a href='https://joinmastodon.org/imprint'>{{ i18n "imprint" }}</a></p>
 </footer>


### PR DESCRIPTION
When I was working on https://github.com/mastodon/documentation/pull/1425 I was getting errors from this line.

I am not a hugo expert and genuinely have no idea what I'm doing here, however I found that with huge latest version (0.124.1) installed locally the error was solved by this change. I note that the build script here is specifically using an older version ... where presumably this error doesn't occur? 