### PR TITLE
Document new OAuth changes for 4.3.0

### DIFF
--- a/archetypes/methods.md
+++ b/archetypes/methods.md
@@ -32,7 +32,7 @@ x.x.x - added
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -32,6 +32,7 @@ $darker: $classic-primary-color;
 
 $vibrant: lighten($blurple-500, 8%); // color4
 $error: $warning-red; // color6
+$warning: $gold-star;
 $success: $success-green; // color7
 
 $background-border-color: lighten($classic-base-color, 4%);
@@ -903,6 +904,20 @@ main {
     font-size: 12px;
     font-weight: 500;
     color: $error;
+  }
+
+  &-removed {
+    text-transform: uppercase;
+    font-size: 12px;
+    font-weight: 500;
+    color: $error;
+  }
+
+  &-deprecated {
+    text-transform: uppercase;
+    font-size: 12px;
+    font-weight: 500;
+    color: $warning;
   }
 
   &-optional {

--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -303,10 +303,11 @@ The streaming API can be deployed to a different domain/subdomain. This may impr
 
 Example value: `wss://streaming.example.com`
 
-#### `STREAMING_CLUSTER_NUM` (deprecated) {#streaming_cluster_num}
+#### `STREAMING_CLUSTER_NUM` {{%removed%}} {#streaming_cluster_num}
 
 {{< hint style="danger" >}}
-Deprecated: The streaming server process now only uses a single node.js process, to scale it further, you'll need to follow the documentation in the [scaling guide](/admin/scaling#streaming)
+**Removed:**\
+The streaming server process now only uses a single node.js process, to scale it further, you'll need to follow the documentation in the [scaling guide](/admin/scaling#streaming)
 {{< /hint >}}
 
 Specific to the streaming API, this variable determines how many different processes the streaming API forks into. Defaults to the number of CPU cores minus one.
@@ -1048,7 +1049,7 @@ If set, registrations confirm page will display a captcha, see [Captcha](https:/
 
 If set, registrations will not be possible with any e-mails **except** those from the specified domains. Pipe-separated values, e.g.: `foo.com|bar.com`
 
-#### `EMAIL_DOMAIN_DENYLIST`
+#### `EMAIL_DOMAIN_DENYLIST` {{%deprecated%}}
 
 If set, registrations will not be possible with any e-mails from the specified domains. Pipe-separated values, e.g.: `foo.com|bar.com`
 

--- a/content/en/api/guidelines.md
+++ b/content/en/api/guidelines.md
@@ -13,7 +13,7 @@ menu:
 
 {{< page-ref page="client/authorized" >}}
 
-{{< page-relref ref="methods/oauth" caption="oauth methods" >}}
+{{< page-relref ref="methods/oauth" caption="OAuth methods" >}}
 
 {{< page-relref ref="api/oauth-scopes" caption="OAuth scopes" >}}
 

--- a/content/en/api/guidelines.md
+++ b/content/en/api/guidelines.md
@@ -58,7 +58,7 @@ To get around this, Mastodon may return links to a "prev" and "next" page. These
 
 ```http
 GET https://mastodon.example/api/v1/endpoint HTTP/1.1
-Authorization: Bearer token
+Authorization: Bearer <access_token>
 
 Link: <https://mastodon.example/api/v1/endpoint?max_id=7163058>; rel="next", <https://mastodon.example/api/v1/endpoint?min_id=7275607>; rel="prev"
 [

--- a/content/en/api/oauth-scopes.md
+++ b/content/en/api/oauth-scopes.md
@@ -61,7 +61,7 @@ If you do not specify `scope` in your authorization request, or `scopes` in your
 
 ## List of high-level scopes
 
-We recommend that you use the [granular scopes](#granular) shown in the right column of the table below, instead of using the following scopes:
+We recommend that you use the [granular scopes](#granular-scopes) shown in the right column of the table below, instead of using the following scopes:
 
 - `read`
 - `write`
@@ -77,11 +77,11 @@ Grants access only to the [`GET /api/v1/accounts/verify_credentials`]({{< relref
 
 ### `read` {#read}
 
-Grants access to read data, including other users. Requesting `read` will also grant [granular scopes](#granular) shown in the right column of the table below.
+Grants access to read data, including other users. Requesting `read` will also grant [granular scopes](#granular-scopes) shown in the right column of the table below.
 
 ### `write` {#write}
 
-Grants access to write data. Requesting `write` will also grant [granular scopes](#granular) shown in the right column of the table below.
+Grants access to write data. Requesting `write` will also grant [granular scopes](#granular-scopes) shown in the right column of the table below.
 
 ### `push` {#push}
 
@@ -91,16 +91,16 @@ Grants access to [Web Push API subscriptions.]({{< relref "methods/push" >}}) Ad
 
 {{< hint style="danger" >}}
 **Deprecated**\
-This scope has been deprecated in 3.5.0 and newer. You should instead request the [granular scopes](#granular) individually, or request `read`/`write` scopes as needed.
+This scope has been deprecated in 3.5.0 and newer. You should instead request the [granular scopes](#granular-scopes) individually, or request `read`/`write` scopes as needed.
 {{< /hint >}}
 
-Grants access to manage relationships. Requesting `follow` will also grant [granular scopes](#granular) shown in the right column of the table below.
+Grants access to manage relationships. Requesting `follow` will also grant [granular scopes](#granular-scopes) shown in the right column of the table below.
 
 ### `admin:read` and `admin:write` {#admin}
 
 Used for administrative and moderation APIs. Added in Mastodon 2.9.1.
 
-Requesting `admin:read` or `admin:write` will also grant [granular scopes](#granular) shown in the right column of the table below.
+Requesting `admin:read` or `admin:write` will also grant [granular scopes](#granular-scopes) shown in the right column of the table below.
 
 {{< hint style="info" >}}
 Note that there is no singular `admin` scope available.

--- a/content/en/api/oauth-scopes.md
+++ b/content/en/api/oauth-scopes.md
@@ -47,7 +47,7 @@ If you do not specify `scope` in your authorization request, or `scopes` in your
 - 2.9.1 - Admin scopes added [#9387](https://github.com/mastodon/mastodon/pull/9387)
 - 3.1.0 - Bookmark scopes added [#7107](https://github.com/mastodon/mastodon/pull/7107)
 - 4.1.0 - Added admin scopes for blocks and allows [#20918](https://github.com/mastodon/mastodon/pull/20918)
-- 4.3.0 - Added `read:me` scope for when you want just basic information about the currently authenticated account. [#29087](https://github.com/mastodon/mastodon/pull/29087)
+- 4.3.0 - Added `read:me` scope to obtain basic information about the currently authenticated account. [#29087](https://github.com/mastodon/mastodon/pull/29087)
 
 ## List of high-level scopes
 

--- a/content/en/api/oauth-scopes.md
+++ b/content/en/api/oauth-scopes.md
@@ -163,3 +163,7 @@ It is recommended that you make use of granular scopes, unless you really need f
 |                           | `admin:write:ip_blocks`              |
 |                           | `admin:write:email_domain_blocks`    |
 |                           | `admin:write:canonical_email_blocks` |
+
+## Removed scopes {#removed}
+
+* Mastodon versions from 3.2.0 to 4.3.0 did support a `crypto` scope for end-to-end encryption APIs, however, this functionality was never documented nor fully implemented, and has been removed as of version 4.3.0. Any applications registered with that scope will have the scope removed when the server is upgraded to 4.3.0 and above.

--- a/content/en/api/oauth-scopes.md
+++ b/content/en/api/oauth-scopes.md
@@ -12,7 +12,7 @@ menu:
 The API is divided up into access scopes. The scopes are hierarchical, i.e. if you have access to `read`, you automatically have access to `read:accounts`. **It is recommended that you request as little as possible for your application.**
 
 {{< hint style="info" >}}
-If you just want to retrieve the basic details of the currently authenticated user, use the `read:me` scope, which can only access the [`GET /api/v1/accounts/verify_credentials`]({{< relref "methods/accounts#verify_credentials" >}}) endpoint.
+To retrieve the basic details of the currently authenticated user, use the `read:me` scope, which can only access the [`GET /api/v1/accounts/verify_credentials`]({{< relref "methods/accounts#verify_credentials" >}}) endpoint.
 {{</ hint >}}
 
 ### Discovering OAuth Scopes supported by a given Mastodon Server

--- a/content/en/api/oauth-scopes.md
+++ b/content/en/api/oauth-scopes.md
@@ -9,7 +9,7 @@ menu:
 
 ## OAuth Scopes
 
-The API access is divided up into several OAuth scopes, these limit what an API client can do, based on the registered and requested scopes that the user has approved. The scopes in Mastodon are hierarchical, for example, if you have request the `read` scope, you automatically have access to `read:accounts`, however **it is recommended that you request the most limited scopes as possible for your application**, i.e., if you only need to access lists and the current user profile, you could use `profile read:lists` as your scopes, instead of `read`.
+The API access is divided up into several OAuth scopes, these limit what an API client can do, based on the registered and requested scopes for the [Access Token]({{< relref "api/oauth-tokens" >}}). The scopes in Mastodon are hierarchical, for example, if you request the `read` scope, you automatically have access to `read:accounts`, however **we recommend that you request the most limited scopes as possible for your application**, i.e., if you only need read access to lists and the current user profile, then you should use `profile read:lists` as your scopes instead of `read`.
 
 {{< hint style="info" >}}
 To just retrieve the details of the currently authenticated user, use the `profile` scope, which can only access the [`GET /api/v1/accounts/verify_credentials`]({{< relref "methods/accounts#verify_credentials" >}}) endpoint.\
@@ -20,7 +20,7 @@ This scope was added in Mastodon 4.3, so we recommend using the "Discovering OAu
 
 As of Mastodon 4.3.0, support for [RFC 8414](https://tools.ietf.org/html/rfc8414)'s `GET /.well-known/oauth-authorization-server` endpoint was added, allowing you to discover the scopes supported by the Mastodon server (as well as other OAuth related information such as the endpoints and grant flows).
 
-It is recommended using this endpoint in order to support multiple versions of Mastodon for your OAuth Application.
+We recommended using this endpoint in order to support multiple versions of Mastodon for your OAuth Application.
 
 If you make a request to the `GET /.well-known/oauth-authorization-server` endpoint, and it returns a 404, then you can assume that the Mastodon server is running a version older than 4.3, in which case you'll need to look at the specific scopes your application needs and what the lowest common scopes are for the version range of Mastodon that you wish to support.
 

--- a/content/en/api/oauth-scopes.md
+++ b/content/en/api/oauth-scopes.md
@@ -59,7 +59,7 @@ We recommend that you use the [granular scopes](#granular) shown in the right co
 - `admin:read`
 - `admin:write`
 
-If you just want to retrieve the basic details of the currently authenticated user, use the `read:me` scope.
+When only the basic details of the currently authenticated user are required, use the `read:me` scope.
 
 ### `read:me` {#read-me}
 

--- a/content/en/api/oauth-scopes.md
+++ b/content/en/api/oauth-scopes.md
@@ -32,7 +32,7 @@ If you make a request to the `GET /.well-known/oauth-authorization-server` endpo
 
 ### Multiple scopes can be requested at the same time
 
-During application creation with the `scopes` parameter you can specify multiple space-separated scopes, and during the authorization phase with the `scope` query parameter (space-separate the scopes).
+During application creation you can specify multiple space-separated scopes with the `scopes` parameter. During the authorization phase you can do the same with the `scope` query parameter.
 
 {{< hint style="danger" >}}
 The set of scopes saved during application creation must include all the scopes that you will request in the authorization request, otherwise, authorization will fail.

--- a/content/en/api/oauth-scopes.md
+++ b/content/en/api/oauth-scopes.md
@@ -35,7 +35,7 @@ The set of scopes saved during application creation must include all the scopes 
 Mind the `scope` vs `scopes` difference. This is because `scope` is a standard OAuth parameter name, so it is used in the OAuth methods. Mastodon’s own REST API uses the more appropriate `scopes`.
 {{< /hint >}}
 
-If you do not specify a `scope` in your authorization request, or a `scopes` in your application creation request, the resulting access token/app will default to `read` access. This is subject to change in the future.
+If you do not specify `scope` in your authorization request, or `scopes` in your application creation request, the resulting access token/app will be assigned the default scope. This is currently `read` as of Mastodon 4.3.0, but is subject to change in the future.
 
 ### Version history {#versions}
 

--- a/content/en/api/oauth-scopes.md
+++ b/content/en/api/oauth-scopes.md
@@ -11,128 +11,145 @@ menu:
 
 The API is divided up into access scopes. The scopes are hierarchical, i.e. if you have access to `read`, you automatically have access to `read:accounts`. **It is recommended that you request as little as possible for your application.**
 
-Multiple scopes can be requested at the same time: During app creation with the `scopes` param, and during the authorization phase with the `scope` query param (space-separate the scopes).
+{{< hint style="info" >}}
+If you just want to retrieve the basic details of the currently authenticated user, use the `read:me` scope, which can only access the [`GET /api/v1/accounts/verify_credentials`]({{< relref "methods/accounts#verify_credentials" >}}) endpoint.
+{{</ hint >}}
+
+### Discovering OAuth Scopes supported by a given Mastodon Server
+
+As of Mastodon 4.3.0, we can make a request to `GET /.well-known/oauth-authorization-server` to discover the scopes supported by the Mastodon server (as well as other OAuth related information such as endpoints and grant flows).
+
+It is recommended that you do this if you need to support multiple versions of Mastodon for your OAuth Application.
+
+{{< page-relref ref="methods/oauth#authorization-server-metadata" caption="GET /.well-known/oauth-authorization-server" >}}
+
+### Multiple scopes can be requested at the same time
+
+During application creation with the `scopes` parameter you can specify multiple space-separated scopes, and during the authorization phase with the `scope` query parameter (space-separate the scopes).
+
+{{< hint style="danger" >}}
+The set of scopes saved during application creation must include all the scopes that you will request in the authorization request, otherwise, authorization will fail.
+{{< /hint >}}
 
 {{< hint style="info" >}}
 Mind the `scope` vs `scopes` difference. This is because `scope` is a standard OAuth parameter name, so it is used in the OAuth methods. Mastodon’s own REST API uses the more appropriate `scopes`.
 {{< /hint >}}
 
-If you do not specify a `scope` in your authorization request, or a `scopes` in your app creation request, the resulting access token/app will default to `read` access.
-
-The set of scopes saved during app creation must include all the scopes that you will request in the authorization request, otherwise, authorization will fail.
+If you do not specify a `scope` in your authorization request, or a `scopes` in your application creation request, the resulting access token/app will default to `read` access. This is subject to change in the future.
 
 ### Version history {#versions}
 
 - 0.9.0 - read, write, follow
 - 2.4.0 - push
-- 2.4.3 - granular scopes [#7929](https://github.com/mastodon/mastodon/pull/7929)
-- 2.6.0 - read:reports deprecated (unused stub) [#8736/adcf23f](https://github.com/mastodon/mastodon/pull/8736/commits/adcf23f1d00c8ff6877ca2ee2af258f326ae4e1f)
-- 2.6.0 - write:conversations added [#9009](https://github.com/mastodon/mastodon/pull/9009)
+- 2.4.3 - granular scopes added [#7929](https://github.com/mastodon/mastodon/pull/7929)
+- 2.6.0 - `read:reports` deprecated (unused stub) [#8736/adcf23f](https://github.com/mastodon/mastodon/pull/8736/commits/adcf23f1d00c8ff6877ca2ee2af258f326ae4e1f)
+- 2.6.0 - `write:conversations` added [#9009](https://github.com/mastodon/mastodon/pull/9009)
 - 2.9.1 - Admin scopes added [#9387](https://github.com/mastodon/mastodon/pull/9387)
 - 3.1.0 - Bookmark scopes added [#7107](https://github.com/mastodon/mastodon/pull/7107)
 - 4.1.0 - Added admin scopes for blocks and allows [#20918](https://github.com/mastodon/mastodon/pull/20918)
+- 4.3.0 - Added `read:me` scope for when you want just basic information about the currently authenticated account. [#29087](https://github.com/mastodon/mastodon/pull/29087)
 
-## List of scopes
+## List of high-level scopes
+
+We recommend that you use the [granular scopes](#granular) shown in the right column of the table below, instead of using the following scopes:
+
+- `read`
+- `write`
+- `follow` (deprecated)
+- `admin:read`
+- `admin:write`
+
+If you just want to retrieve the basic details of the currently authenticated user, use the `read:me` scope.
+
+### `read:me` {#read-me}
+
+Grants access only to the [`GET /api/v1/accounts/verify_credentials`]({{< relref "methods/accounts#verify_credentials" >}}) endpoint. Allowing you to retrieve information only about the currently authenticated account.
 
 ### `read` {#read}
 
-Grants access to read data. Requesting `read` will also grant child scopes shown in the left column of the table below.
-
-* `read`
-  * `read:accounts`
-  * `read:blocks`
-  * `read:bookmarks`
-  * `read:favourites`
-  * `read:filters`
-  * `read:follows`
-  * `read:lists`
-  * `read:mutes`
-  * `read:notifications`
-  * `read:search`
-  * `read:statuses`
+Grants access to read data, including other users. Requesting `read` will also grant [granular scopes](#granular) shown in the right column of the table below.
 
 ### `write` {#write}
 
-Grants access to write data. Requesting `write` will also grant child scopes shown in the right column of the table below.
-
-* `write`
-  * `write:accounts`
-  * `write:blocks`
-  * `write:bookmarks`
-  * `write:conversations`
-  * `write:favourites`
-  * `write:filters`
-  * `write:follows`
-  * `write:lists`
-  * `write:media`
-  * `write:mutes`
-  * `write:notifications`
-  * `write:reports`
-  * `write:statuses`
+Grants access to write data. Requesting `write` will also grant [granular scopes](#granular) shown in the right column of the table below.
 
 ### `follow` {#follow}
 
 {{< hint style="danger" >}}
 **Deprecated**\
-This scope has been deprecated in 3.5.0 and newer. You should instead request the child scopes individually, or request read/write permission as needed.
+This scope has been deprecated in 3.5.0 and newer. You should instead request the [granular scopes](#granular) individually, or request `read`/`write` scopes as needed.
 {{< /hint >}}
 
-Grants access to manage relationships. Requesting `follow` will also grant the following child scopes, shown in bold in the table:
-
-* `read:blocks`, `write:blocks`
-* `read:follows`, `write:follows`
-* `read:mutes`, `write:mutes`
+Grants access to manage relationships. Requesting `follow` will also grant [granular scopes](#granular) shown in the right column of the table below.
 
 ### `push` {#push}
 
 Grants access to [Web Push API subscriptions.]({{< relref "methods/push" >}}) Added in Mastodon 2.4.0.
 
-### Admin scopes {#admin}
+### `admin:read` and `admin:write` {#admin}
 
-Used for moderation API. Added in Mastodon 2.9.1. The following granular scopes are available (note that there is no singular `admin` scope):
+Used for administrative and moderation APIs. Added in Mastodon 2.9.1.
 
-* `admin:read`
-  * `admin:read:accounts`
-  * `admin:read:reports`
-  * `admin:read:domain_allows`
-  * `admin:read:domain_blocks`
-  * `admin:read:ip_blocks`
-  * `admin:read:email_domain_blocks`
-  * `admin:read:canonical_email_blocks`
-* `admin:write`
-  * `admin:write:accounts`
-  * `admin:write:reports`
-  * `admin:write:domain_allows`
-  * `admin:write:domain_blocks`
-  * `admin:write:ip_blocks`
-  * `admin:write:email_domain_blocks`
-  * `admin:write:canonical_email_blocks`
+Requesting `admin:read` or `admin:write` will also grant [granular scopes](#granular) shown in the right column of the table below.
+
+{{< hint style="info" >}}
+Note that there is no singular `admin` scope available.
+{{< /hint >}}
 
 ## Granular scopes {#granular}
 
-| read | write |
-| :--- | :--- |
-| read:accounts | write:accounts |
-| **read:blocks** | **write:blocks** |
-| read:bookmarks | write:bookmarks |
-|  | write:conversations |
-| read:favourites | write:favourites |
-| read:filters | write:filters |
-| **read:follows** | **write:follows** |
-| read:lists | write:lists |
-|  | write:media |
-| **read:mutes** | **write:mutes** |
-| read:notifications | write:notifications |
-|  | write:reports |
-| read:search |  |
-| read:statuses | write:statuses |
+It is recommended that you make use of granular scopes, unless you really need full access to everything by using a `scope` of `read write follow push`.
 
-| admin:read | admin:write |
-| :--- | :--- |
-| admin:read:accounts | admin:write:accounts |
-| admin:read:reports | admin:write:reports |
-| admin:read:domain_allows | admin:write:domain_allows | 
-| admin:read:domain_blocks | admin:write:domain_blocks |
-| admin:read:ip_blocks | admin:write:ip_blocks |
-| admin:read:email_domain_blocks | admin:write:email_domain_blocks |
-| admin:read:canonical_email_blocks | admin:write:canonical_email_blocks |
+| Scope                 | Granular Scopes                      |
+| :-------------------- | :----------------------------------- |
+| `read`                |                                      |
+|                       | `read:accounts`                      |
+|                       | `read:blocks`                        |
+|                       | `read:bookmarks`                     |
+|                       | `read:favourites`                    |
+|                       | `read:filters`                       |
+|                       | `read:follows`                       |
+|                       | `read:lists`                         |
+|                       | `read:mutes`                         |
+|                       | `read:notifications`                 |
+|                       | `read:search`                        |
+|                       | `read:statuses`                      |
+|                       | `read:me`                            |
+| `write`               |                                      |
+|                       | `write:accounts`                     |
+|                       | `write:blocks`                       |
+|                       | `write:bookmarks`                    |
+|                       | `write:conversations`                |
+|                       | `write:favourites`                   |
+|                       | `write:filters`                      |
+|                       | `write:follows`                      |
+|                       | `write:lists`                        |
+|                       | `write:media`                        |
+|                       | `write:mutes`                        |
+|                       | `write:notifications`                |
+|                       | `write:reports`                      |
+|                       | `write:statuses`                     |
+| `follow` (deprecated) |                                      |
+|                       | `read:follows`                       |
+|                       | `write:follows`                      |
+|                       | `read:blocks`                        |
+|                       | `write:blocks`                       |
+|                       | `read:mutes`                         |
+|                       | `write:mutes`                        |
+| `push`                |                                      |
+| `admin:read`          |                                      |
+|                       | `admin:read:accounts`                |
+|                       | `admin:read:reports`                 |
+|                       | `admin:read:domain_allows`           |
+|                       | `admin:read:domain_blocks`           |
+|                       | `admin:read:ip_blocks`               |
+|                       | `admin:read:email_domain_blocks`     |
+|                       | `admin:read:canonical_email_blocks`  |
+| `admin:write`         |                                      |
+|                       | `admin:write:accounts`               |
+|                       | `admin:write:reports`                |
+|                       | `admin:write:domain_allows`          |
+|                       | `admin:write:domain_blocks`          |
+|                       | `admin:write:ip_blocks`              |
+|                       | `admin:write:email_domain_blocks`    |
+|                       | `admin:write:canonical_email_blocks` |

--- a/content/en/api/oauth-scopes.md
+++ b/content/en/api/oauth-scopes.md
@@ -55,7 +55,7 @@ We recommend that you use the [granular scopes](#granular) shown in the right co
 
 - `read`
 - `write`
-- `follow` (deprecated)
+- `follow` {{%deprecated%}}
 - `admin:read`
 - `admin:write`
 
@@ -100,56 +100,56 @@ Note that there is no singular `admin` scope available.
 
 It is recommended that you make use of granular scopes, unless you really need full access to everything by using a `scope` of `read write follow push`.
 
-| Scope                 | Granular Scopes                      |
-| :-------------------- | :----------------------------------- |
-| `read`                |                                      |
-|                       | `read:accounts`                      |
-|                       | `read:blocks`                        |
-|                       | `read:bookmarks`                     |
-|                       | `read:favourites`                    |
-|                       | `read:filters`                       |
-|                       | `read:follows`                       |
-|                       | `read:lists`                         |
-|                       | `read:mutes`                         |
-|                       | `read:notifications`                 |
-|                       | `read:search`                        |
-|                       | `read:statuses`                      |
-|                       | `read:me`                            |
-| `write`               |                                      |
-|                       | `write:accounts`                     |
-|                       | `write:blocks`                       |
-|                       | `write:bookmarks`                    |
-|                       | `write:conversations`                |
-|                       | `write:favourites`                   |
-|                       | `write:filters`                      |
-|                       | `write:follows`                      |
-|                       | `write:lists`                        |
-|                       | `write:media`                        |
-|                       | `write:mutes`                        |
-|                       | `write:notifications`                |
-|                       | `write:reports`                      |
-|                       | `write:statuses`                     |
-| `follow` (deprecated) |                                      |
-|                       | `read:follows`                       |
-|                       | `write:follows`                      |
-|                       | `read:blocks`                        |
-|                       | `write:blocks`                       |
-|                       | `read:mutes`                         |
-|                       | `write:mutes`                        |
-| `push`                |                                      |
-| `admin:read`          |                                      |
-|                       | `admin:read:accounts`                |
-|                       | `admin:read:reports`                 |
-|                       | `admin:read:domain_allows`           |
-|                       | `admin:read:domain_blocks`           |
-|                       | `admin:read:ip_blocks`               |
-|                       | `admin:read:email_domain_blocks`     |
-|                       | `admin:read:canonical_email_blocks`  |
-| `admin:write`         |                                      |
-|                       | `admin:write:accounts`               |
-|                       | `admin:write:reports`                |
-|                       | `admin:write:domain_allows`          |
-|                       | `admin:write:domain_blocks`          |
-|                       | `admin:write:ip_blocks`              |
-|                       | `admin:write:email_domain_blocks`    |
-|                       | `admin:write:canonical_email_blocks` |
+| Scope                     | Granular Scopes                      |
+| :------------------------ | :----------------------------------- |
+| `profile`                 |                                      |
+| `push`                    |                                      |
+| `read`                    |                                      |
+|                           | `read:accounts`                      |
+|                           | `read:blocks`                        |
+|                           | `read:bookmarks`                     |
+|                           | `read:favourites`                    |
+|                           | `read:filters`                       |
+|                           | `read:follows`                       |
+|                           | `read:lists`                         |
+|                           | `read:mutes`                         |
+|                           | `read:notifications`                 |
+|                           | `read:search`                        |
+|                           | `read:statuses`                      |
+| `write`                   |                                      |
+|                           | `write:accounts`                     |
+|                           | `write:blocks`                       |
+|                           | `write:bookmarks`                    |
+|                           | `write:conversations`                |
+|                           | `write:favourites`                   |
+|                           | `write:filters`                      |
+|                           | `write:follows`                      |
+|                           | `write:lists`                        |
+|                           | `write:media`                        |
+|                           | `write:mutes`                        |
+|                           | `write:notifications`                |
+|                           | `write:reports`                      |
+|                           | `write:statuses`                     |
+| `follow` {{%deprecated%}} |                                      |
+|                           | `read:follows`                       |
+|                           | `write:follows`                      |
+|                           | `read:blocks`                        |
+|                           | `write:blocks`                       |
+|                           | `read:mutes`                         |
+|                           | `write:mutes`                        |
+| `admin:read`              |                                      |
+|                           | `admin:read:accounts`                |
+|                           | `admin:read:reports`                 |
+|                           | `admin:read:domain_allows`           |
+|                           | `admin:read:domain_blocks`           |
+|                           | `admin:read:ip_blocks`               |
+|                           | `admin:read:email_domain_blocks`     |
+|                           | `admin:read:canonical_email_blocks`  |
+| `admin:write`             |                                      |
+|                           | `admin:write:accounts`               |
+|                           | `admin:write:reports`                |
+|                           | `admin:write:domain_allows`          |
+|                           | `admin:write:domain_blocks`          |
+|                           | `admin:write:ip_blocks`              |
+|                           | `admin:write:email_domain_blocks`    |
+|                           | `admin:write:canonical_email_blocks` |

--- a/content/en/api/oauth-tokens.md
+++ b/content/en/api/oauth-tokens.md
@@ -1,0 +1,27 @@
+---
+title: OAuth Tokens
+description: Defining what token types are used throughout this documentation
+menu:
+  docs:
+    weight: 15
+    parent: api
+---
+
+## OAuth Tokens
+
+Mastodon supports two different types of OAuth Tokens: App tokens and User tokens. Throughout this documentation you will see these token types referenced in the `OAuth` field for API endpoints.
+
+The `OAuth` field also references Public, in which case no OAuth access token needs to be supplied to access the API endpoint.
+
+### App tokens
+
+In order to receive an App token, you must perform a [client credentials grant flow]({{<relref "client/token#flow" >}}), which gives you a token that can be used to interact with the API on behalf of the OAuth Application. Currently the only API endpoints that accepts this token type are:
+
+- [`GET /api/v1/apps/verify_credentials`]({{<relref "methods/apps#verify_credentials" >}})
+- [`POST /api/v1/accounts`]({{<relref "/methods/accounts#create" >}})
+
+### User tokens
+
+In order to create a User token, you must perform a [authorization code grant flow]({{<relref "client/authorized#flow">}}), which gives you an access token that is associated with the user who approves the access grant request.
+
+Many Mastodon APIs require User tokens and specific scopes to access them.

--- a/content/en/client/authorized.md
+++ b/content/en/client/authorized.md
@@ -83,7 +83,7 @@ Let's verify that our obtained credentials are working by calling [GET /api/v1/a
 
 ```bash
 curl \
-	-H 'Authorization: Bearer our_access_token_here' \
+	-H 'Authorization: Bearer <access_token>' \
 	https://mastodon.example/api/v1/accounts/verify_credentials
 ```
 

--- a/content/en/client/authorized.md
+++ b/content/en/client/authorized.md
@@ -11,9 +11,9 @@ menu:
 
 When we register our app and when we authorize our user, we need to define what exactly our generated token will have permission to do. This is done through the use of [OAuth Scopes]({{< relref "api/oauth-scopes" >}}). Each API method has an associated scope, and can only be called if the token being used for authorization has been generated with the corresponding scope.
 
-When authorizing a user, the `scope` query parameter must be a subset of those we specified when we created our app, in our ongoing example, we specified `read write push`, however it is a better idea to only request what your app will actually need through [granular scopes]({{< relref "api/oauth-scopes#granular-scopes" >}}).
+When authorizing a user, the `scope` query parameter must be a subset of those we specified when we created our app. In our ongoing example, we specified `read write push` as our scopes when we created our app, however it is a better idea to only request access to what your app will actually need through [granular scopes]({{< relref "api/oauth-scopes#granular-scopes" >}}).
 
-See [OAuth Scopes]({{< relref "api/oauth-scopes" >}}) for a full list of scopes. Each API method's documentation will also specify the OAuth [token type]({{< relref "api/oauth-tokens" >}}) and the scopes required to call it. If an endpoint specifies `read:statuses` and you have `read` then you will be able to access that endpoint, since scopes are hierarchial.
+See [OAuth Scopes]({{< relref "api/oauth-scopes" >}}) for a full list of scopes. Each API method's documentation will also specify the OAuth [token type]({{< relref "api/oauth-tokens" >}}) and the scopes required to call it. If an endpoint specifies `read:statuses` and you have `read` access, then you will be able to use that endpoint, since scopes are hierarchial.
 
 {{< page-relref ref="api/oauth-scopes" caption="OAuth Scopes" >}}
 

--- a/content/en/client/authorized.md
+++ b/content/en/client/authorized.md
@@ -37,7 +37,13 @@ Note the following:
 
 * `client_id` was obtained when registering our application.
 * `scope` must be a subset of our app's registered scopes. It is a good idea to only request what you need. See [OAuth Scopes]({{< relref "api/oauth-scopes" >}}) for more information.
-* `redirect_uri` is one of the URIs we registered with our app. We are still using "out of band" for this example, which means we will have to manually copy and paste the resulting code, but if you registered your application with a URI that you control, then the code will be returned as a query parameter `code` and can be logged by your request handler. See the response section of the API method documentation for more information on this.
+* `redirect_uri` is one of the URIs we registered with our app.
+
+We are still using "out of band" for this example, which means we will have to manually copy and paste the resulting code, but if you registered your application with a URI that you control, then the code will be returned as a query parameter `code` by your request handler for the redirect URI. See the response section of the API method documentation for more information on this.
+
+{{< hint style="warning" >}}
+Treat the `code` query parameter as if it were a password, you should ensure that it is not logged in request logs.
+{{< /hint >}}
 
 ### Obtain the token {#token}
 
@@ -56,12 +62,20 @@ curl -X POST \
 
 Note the following:
 
-* `client_id` and `client_secret` were provided in the response text when you registered your application.
-* `redirect_uri` must be one of the URIs defined when registering the application.
-* We are requesting a `grant_type` of `authorization_code`, which still defaults to giving us the `read` scope. However, while authorizing our user, we requested a certain `scope` -- pass the exact same value here.
-* The `code` can only be used once. If you need to obtain a new token, you will need to have the user authorize again by repeating the above [Authorize the user]({{< relref "client/authorized#authorize-the-user" >}}) step.
+- `client_id` and `client_secret` were provided in the response text when you registered your application.
+- `redirect_uri` must be one of the URIs defined when registering the application.
+- We are requesting a `grant_type` of `authorization_code`, which still defaults to giving us the `read` scope. However, while authorizing our user, we requested a certain `scope` -- pass the exact same value here.
+- The `code` can only be used once. If you need to obtain a new token, you will need to have the user authorize again by repeating the above [Authorize the user]({{< relref "client/authorized#authorize-the-user" >}}) step.
 
-The response of this method is a [Token]({{< relref "entities/token" >}}) entity. We will need the `access_token` value. Once you have the access token, save it in your local cache. To use it in requests, add the HTTP header `Authorization: Bearer ...` to any API call that requires OAuth (i.e., one that is not publicly accessible). Let's verify that our obtained credentials are working by calling [GET /api/v1/accounts/verify_credentials]({{< relref "methods/accounts#verify_credentials" >}}):
+The response of this method is a [Token]({{< relref "entities/token" >}}) entity. We will need the `access_token` value. Once you have the access token, save it in your local cache.
+
+{{< hint style="warning" >}}
+Treat the `access_token` as if it were a password. We recommend you encrypt this value when storing in your cache, to prevent accidental credential exposure.
+{{< /hint >}}
+
+To use it in requests, add the HTTP header `Authorization: Bearer <access_token>` to any API call that requires OAuth (i.e., one that is not publicly accessible).
+
+Let's verify that our obtained credentials are working by calling [GET /api/v1/accounts/verify_credentials]({{< relref "methods/accounts#verify_credentials" >}}):
 
 ```bash
 curl \
@@ -77,48 +91,47 @@ With our OAuth token for the authorized user, we can now perform any action as t
 
 ### Publish and delete statuses {#statuses}
 
-* See [POST /api/v1/statuses]({{< relref "methods/statuses#create" >}}) for how to create statuses.
-  * See [/api/v1/media]({{< relref "methods/media" >}}) for creating media attachments.
-  * See [/api/v1/scheduled_statuses]({{< relref "methods/scheduled_statuses" >}}) for managing scheduled statuses.
+- See [POST /api/v1/statuses]({{< relref "methods/statuses#create" >}}) for how to create statuses.
+  - See [/api/v1/media]({{< relref "methods/media" >}}) for creating media attachments.
+  - See [/api/v1/scheduled_statuses]({{< relref "methods/scheduled_statuses" >}}) for managing scheduled statuses.
 
 ### Interact with timelines {#timelines}
 
-* See [/api/v1/timelines]({{< relref "methods/timelines" >}}) for accessing timelines.
-* See [/api/v1/markers]({{< relref "methods/markers" >}}) for saving and loading positions in timelines.
-* See [/api/v1/statuses]({{< relref "methods/statuses" >}}) for performing actions on statuses.
-  * See [/api/v1/polls]({{< relref "methods/polls" >}}) for viewing and voting on polls.
-* See [/api/v1/lists]({{< relref "methods/lists" >}}) for obtaining list IDs to use with [GET /api/v1/timelines/list/:list_id]({{< relref "methods/timelines#list" >}}).
-* See [/api/v1/conversations]({{< relref "methods/conversations" >}}) for obtaining direct conversations.
-* See [/api/v1/favourites]({{< relref "methods/favourites" >}}) for listing favourites.
-* See [/api/v1/bookmarks]({{< relref "methods/bookmarks" >}}) for listing bookmarks.
+- See [/api/v1/timelines]({{< relref "methods/timelines" >}}) for accessing timelines.
+- See [/api/v1/markers]({{< relref "methods/markers" >}}) for saving and loading positions in timelines.
+- See [/api/v1/statuses]({{< relref "methods/statuses" >}}) for performing actions on statuses.
+  - See [/api/v1/polls]({{< relref "methods/polls" >}}) for viewing and voting on polls.
+- See [/api/v1/lists]({{< relref "methods/lists" >}}) for obtaining list IDs to use with [GET /api/v1/timelines/list/:list_id]({{< relref "methods/timelines#list" >}}).
+- See [/api/v1/conversations]({{< relref "methods/conversations" >}}) for obtaining direct conversations.
+- See [/api/v1/favourites]({{< relref "methods/favourites" >}}) for listing favourites.
+- See [/api/v1/bookmarks]({{< relref "methods/bookmarks" >}}) for listing bookmarks.
 
 ### Interact with other users {#accounts}
 
-* See [/api/v1/accounts]({{< relref "methods/accounts" >}}) for performing actions on other users.
-* See [/api/v1/follow_requests]({{< relref "methods/follow_requests" >}}) for handling follow requests.
-* See [/api/v1/mutes]({{< relref "methods/mutes" >}}) for listing mutes.
-* See [/api/v1/blocks]({{< relref "methods/blocks" >}}) for listing blocks.
+- See [/api/v1/accounts]({{< relref "methods/accounts" >}}) for performing actions on other users.
+- See [/api/v1/follow_requests]({{< relref "methods/follow_requests" >}}) for handling follow requests.
+- See [/api/v1/mutes]({{< relref "methods/mutes" >}}) for listing mutes.
+- See [/api/v1/blocks]({{< relref "methods/blocks" >}}) for listing blocks.
 
 ### Receive notifications {#notifications}
 
-* See [/api/v1/notifications]({{< relref "methods/notifications" >}}) for managing a user's notifications.
-* See [/api/v1/push]({{< relref "methods/push" >}}) for subscribing to push notifications.
+- See [/api/v1/notifications]({{< relref "methods/notifications" >}}) for managing a user's notifications.
+- See [/api/v1/push]({{< relref "methods/push" >}}) for subscribing to push notifications.
 
 ### Discovery features {#discovery}
 
-* See [/api/v2/search]({{< relref "methods/search#v2" >}}) for querying resources.
-* See [/api/v1/suggestions]({{< relref "methods/suggestions" >}}) for suggested accounts to follow.
+- See [/api/v2/search]({{< relref "methods/search#v2" >}}) for querying resources.
+- See [/api/v1/suggestions]({{< relref "methods/suggestions" >}}) for suggested accounts to follow.
 
 ### User safety features {#safety}
 
-* See [/api/v1/filters]({{< relref "methods/filters" >}}) for managing filtered keywords.
-* See [/api/v1/domain_blocks]({{< relref "methods/domain_blocks" >}}) for managing blocked domains.
-* See [/api/v1/reports]({{< relref "methods/reports" >}}) for creating reports.
-* See [/api/v1/admin]({{< relref "methods/admin" >}}) for moderator actions.
+- See [/api/v1/filters]({{< relref "methods/filters" >}}) for managing filtered keywords.
+- See [/api/v1/domain_blocks]({{< relref "methods/domain_blocks" >}}) for managing blocked domains.
+- See [/api/v1/reports]({{< relref "methods/reports" >}}) for creating reports.
+- See [/api/v1/admin]({{< relref "methods/admin" >}}) for moderator actions.
 
 ### Manage account info {#manage}
 
-* See [/api/v1/endorsements]({{< relref "methods/endorsements" >}}) for managing a user profile's featured accounts.
-* See [/api/v1/featured_tags]({{< relref "methods/featured_tags" >}}) for managing a user profile's featured hashtags.
-* See [/api/v1/preferences]({{< relref "methods/preferences" >}}) for reading user preferences.
-
+- See [/api/v1/endorsements]({{< relref "methods/endorsements" >}}) for managing a user profile's featured accounts.
+- See [/api/v1/featured_tags]({{< relref "methods/featured_tags" >}}) for managing a user profile's featured hashtags.
+- See [/api/v1/preferences]({{< relref "methods/preferences" >}}) for reading user preferences.

--- a/content/en/client/authorized.md
+++ b/content/en/client/authorized.md
@@ -9,9 +9,13 @@ menu:
 
 ## Scopes explained {#scopes}
 
-When we register our app and when we authorize our user, we need to define what exactly our generated token will have permission to do. This is done through the use of OAuth scopes. Each API method has an associated scope, and can only be called if the token being used for authorization has been generated with the corresponding scope.
+When we register our app and when we authorize our user, we need to define what exactly our generated token will have permission to do. This is done through the use of [OAuth Scopes]({{< relref "api/oauth-scopes" >}}). Each API method has an associated scope, and can only be called if the token being used for authorization has been generated with the corresponding scope.
 
-Scopes must be a subset. When we created our app, we specified `read write push` -- we could request all available scopes by specifying `read write push`, but it is a better idea to only request what your app will actually need through granular scopes. See [OAuth Scopes]({{< relref "api/oauth-scopes" >}}) for a full list of scopes. Each API method's documentation will also specify the OAuth access level and scope required to call it.
+When authorizing a user, the `scope` query parameter must be a subset of those we specified when we created our app, in our ongoing example, we specified `read write push`, however it is a better idea to only request what your app will actually need through [granular scopes]({{< relref "api/oauth-scopes#granular-scopes" >}}).
+
+See [OAuth Scopes]({{< relref "api/oauth-scopes" >}}) for a full list of scopes. Each API method's documentation will also specify the OAuth [token type]({{< relref "api/oauth-tokens" >}}) and the scopes required to call it. If an endpoint specifies `read:statuses` and you have `read` then you will be able to access that endpoint, since scopes are hierarchial.
+
+{{< page-relref ref="api/oauth-scopes" caption="OAuth Scopes" >}}
 
 ## **Example authorization code flow** {#flow}
 

--- a/content/en/client/public.md
+++ b/content/en/client/public.md
@@ -25,7 +25,13 @@ We can try to request [GET /api/v1/timelines/public]({{< relref "methods/timelin
 curl https://mastodon.example/api/v1/timelines/public
 ```
 
-Wow, that's a lot of text in response! The public timeline returns 20 statuses by default. We can use the `limit` parameter to request less than that. Let's try requesting the same endpoint, but with a limit of 2 this time:
+Wow, that's a lot of text in response! The public timeline returns 20 statuses by default.
+
+{{< hint style="danger" >}}
+Some Mastodon servers may disable public access to their timelines via the Admin Settings. If this is the case for your server, then you will receive an error response back.
+{{</ hint >}}
+
+We can use the `limit` parameter to request less than that. Let's try requesting the same endpoint, but with a limit of 2 this time:
 
 ```bash
 curl https://mastodon.example/api/v1/timelines/public?limit=2

--- a/content/en/client/token.md
+++ b/content/en/client/token.md
@@ -34,17 +34,16 @@ In the above example, we specify the client name and website, which will be show
 You can also create applications by POSTing a JSON body to the same endpoint, as documented in [POST /api/v1/apps]({{< relref "methods/apps#create-request-example" >}}).
 
 {{< hint style="info" >}}
-As of Mastodon 4.3.0, you can make a request to [`/.well-known/oauth-authorization-server`]({{< relref "spec/oauth#authorization-server-metadata" >}}) to discover which `scopes` the server supports. In older versions of Mastodon, this endpoint will return a 404 not found error, indicating that you should decide on a minimum version of Mastodon to support, and using the scopes supported by that version.
+As of Mastodon 4.3.0, you can discover which `scopes` the server supports along with other information by making a request to the [`/.well-known/oauth-authorization-server`]({{< relref "methods/oauth#authorization-server-metadata" >}}) endpoint.
 {{< /hint >}}
 
 We should see a [CredentialApplication]({{< relref "entities/application#CredentialApplication" >}}) entity returned, but for now, we only care about `client_id` and `client_secret`. 
 
+The `client_id` and `client_secret` values will be used to generate access tokens, so they should be cached for later use. See [POST /api/v1/apps]({{< relref "methods/apps#create" >}}) for more details on registering applications.
+
 {{< hint style="warning" >}}
 Treat the `client_id` and `client_secret` properties as if they are passwords. We recommend you encrypt these when storing in your cache, to prevent accidental credential exposure.
 {{< /hint >}}
-
-The `client_id` and `client_secret` values will be used to generate access tokens, so they should be cached for later use. See [POST /api/v1/apps]({{< relref "methods/apps#create" >}}) for more details on registering applications.
-
 
 ## Example authentication code flow {#flow}
 

--- a/content/en/client/token.md
+++ b/content/en/client/token.md
@@ -34,10 +34,10 @@ In the above example, we specify the client name and website, which will be show
 You can also create applications by POSTing a JSON body to the same endpoint, as documented in [POST /api/v1/apps]({{< relref "methods/apps#create-request-example" >}}).
 
 {{< hint style="info" >}}
-As of Mastodon 4.3.0, you can make a request to [`/.well-known/oauth-authorization-server`]({{< relref "spec/oauth#authorization-server-metadata" >}}) to discover what `scopes` the server supports. In older versions of Mastodon, this endpoint will be a 404, so you should decide a "minimum version supported" for the Mastodon server that your application is interacting with.
+As of Mastodon 4.3.0, you can make a request to [`/.well-known/oauth-authorization-server`]({{< relref "spec/oauth#authorization-server-metadata" >}}) to discover which `scopes` the server supports. In older versions of Mastodon, this endpoint will return a 404 not found error, indicating that you should decide on a minimum version of Mastodon to support, and using the scopes supported by that version.
 {{< /hint >}}
 
-We should see an [CredentialApplication]({{< relref "entities/application#CredentialApplication" >}}) entity returned, but for now, we only care about `client_id` and `client_secret`. 
+We should see a [CredentialApplication]({{< relref "entities/application#CredentialApplication" >}}) entity returned, but for now, we only care about `client_id` and `client_secret`. 
 
 {{< hint style="warning" >}}
 Treat the `client_id` and `client_secret` properties as if they are passwords. We recommend you encrypt these when storing in your cache, to prevent accidental credential exposure.

--- a/content/en/client/token.md
+++ b/content/en/client/token.md
@@ -35,11 +35,14 @@ In the above example, we specify the client name and website, which will be show
 As of Mastodon 4.3.0, you can make a request to [`/.well-known/oauth-authorization-server`]({{< relref "spec/oauth#authorization-server-metadata" >}}) to discover what `scopes` the server supports. In older versions of Mastodon, this endpoint will be a 404, so you should decide a "minimum version supported" for the Mastodon server that your application is interacting with.
 {{< /hint >}}
 
-We should see an [Application]({{< relref "entities/application" >}}) entity returned, but for now, we only care about `client_id` and `client_secret`. These values will be used to generate access tokens, so they should be cached for later use. See [POST /api/v1/apps]({{< relref "methods/apps#create" >}}) for more details on registering applications.
+We should see an [CredentialApplication]({{< relref "entities/application#CredentialApplication" >}}) entity returned, but for now, we only care about `client_id` and `client_secret`. 
 
 {{< hint style="warning" >}}
 Treat the `client_id` and `client_secret` properties as if they are passwords. We recommend you encrypt these when storing in your cache, to prevent accidental credential exposure.
 {{< /hint >}}
+
+The `client_id` and `client_secret` values will be used to generate access tokens, so they should be cached for later use. See [POST /api/v1/apps]({{< relref "methods/apps#create" >}}) for more details on registering applications.
+
 
 ## Example authentication code flow {#flow}
 

--- a/content/en/client/token.md
+++ b/content/en/client/token.md
@@ -31,7 +31,7 @@ In the above example, we specify the client name and website, which will be show
 - `redirect_uris` has been set to the "out of band" token generation, which means that any generated tokens will have to be copied and pasted manually. The parameter is called `redirect_uris` because it is possible to define more than one redirect URI, but when generating the token, we will need to provide a URI that is included within this list.
 - `scopes` allow us to define what permissions we can request later. However, the requested scope later can be a subset of these registered scopes. See [OAuth Scopes]({{< relref "api/oauth-scopes" >}}) for more information.
 
-{{< hint style="warning" >}}
+{{< hint style="info" >}}
 As of Mastodon 4.3.0, you can make a request to [`/.well-known/oauth-authorization-server`]({{< relref "spec/oauth#authorization-server-metadata" >}}) to discover what `scopes` the server supports. In older versions of Mastodon, this endpoint will be a 404, so you should decide a "minimum version supported" for the Mastodon server that your application is interacting with.
 {{< /hint >}}
 

--- a/content/en/client/token.md
+++ b/content/en/client/token.md
@@ -77,7 +77,7 @@ Let's verify that our obtained credentials are working by calling [GET /api/v1/a
 
 ```bash
 curl \
-	-H 'Authorization: Bearer our_access_token_here' \
+	-H 'Authorization: Bearer <access_token>' \
 	https://mastodon.example/api/v1/apps/verify_credentials
 ```
 

--- a/content/en/client/token.md
+++ b/content/en/client/token.md
@@ -28,10 +28,18 @@ curl -X POST \
 
 In the above example, we specify the client name and website, which will be shown on statuses if applicable. But more importantly, note the following two parameters:
 
-* `redirect_uris` has been set to the "out of band" token generation, which means that any generated tokens will have to be copied and pasted manually. The parameter is called `redirect_uris` because it is possible to define more than one redirect URI, but when generating the token, we will need to provide a URI that is included within this list.
-* `scopes` allow us to define what permissions we can request later. However, the requested scope later can be a subset of these registered scopes. See [OAuth Scopes]({{< relref "api/oauth-scopes" >}}) for more information.
+- `redirect_uris` has been set to the "out of band" token generation, which means that any generated tokens will have to be copied and pasted manually. The parameter is called `redirect_uris` because it is possible to define more than one redirect URI, but when generating the token, we will need to provide a URI that is included within this list.
+- `scopes` allow us to define what permissions we can request later. However, the requested scope later can be a subset of these registered scopes. See [OAuth Scopes]({{< relref "api/oauth-scopes" >}}) for more information.
 
-We should see an Application entity returned, but for now, we only care about client_id and client_secret. These values will be used to generate access tokens, so they should be cached for later use. See [POST /api/v1/apps]({{< relref "methods/apps#create" >}}) for more details on registering applications.
+{{< hint style="warning" >}}
+As of Mastodon 4.3.0, you can make a request to [`/.well-known/oauth-authorization-server`]({{< relref "spec/oauth#authorization-server-metadata" >}}) to discover what `scopes` the server supports. In older versions of Mastodon, this endpoint will be a 404, so you should decide a "minimum version supported" for the Mastodon server that your application is interacting with.
+{{< /hint >}}
+
+We should see an [Application]({{< relref "entities/application" >}}) entity returned, but for now, we only care about `client_id` and `client_secret`. These values will be used to generate access tokens, so they should be cached for later use. See [POST /api/v1/apps]({{< relref "methods/apps#create" >}}) for more details on registering applications.
+
+{{< hint style="warning" >}}
+Treat the `client_id` and `client_secret` properties as if they are passwords. We recommend you encrypt these when storing in your cache, to prevent accidental credential exposure.
+{{< /hint >}}
 
 ## Example authentication code flow {#flow}
 
@@ -48,11 +56,19 @@ curl -X POST \
 
 Note the following:
 
-* `client_id` and `client_secret` were provided in the response text when you registered your application.
-* `redirect_uri` must be one of the URIs defined when registering the application.
-* We are requesting a `grant_type` of `client_credentials`, which defaults to giving us the `read` scope.
+- `client_id` and `client_secret` were provided in the response text when you registered your application.
+- `redirect_uri` must be one of the URIs defined when registering the application.
+- We are requesting a `grant_type` of `client_credentials`, which defaults to giving us the `read` scope.
 
-The response of this method is a [Token]({{< relref "entities/token" >}}) entity. We will need the `access_token` value. Once you have the access token, save it in your local cache. To use it in requests, add the HTTP header `Authorization: Bearer ...` to any API call that requires OAuth (i.e., one that is not publicly accessible). Let's verify that our obtained credentials are working by calling [GET /api/v1/apps/verify_credentials]({{< relref "methods/apps#verify_credentials" >}}):
+The response of this method is a [Token]({{< relref "entities/token" >}}) entity. We will need the `access_token` value. Once you have the access token, save it in your local cache.
+
+{{< hint style="warning" >}}
+Treat the `access_token` as if it were a password. We recommend you encrypt this value when storing in your cache, to prevent accidental credential exposure.
+{{< /hint >}}
+
+To use it in requests, add the HTTP header `Authorization: Bearer <access_token>` to any API call that requires OAuth (i.e., one that is not publicly accessible).
+
+Let's verify that our obtained credentials are working by calling [GET /api/v1/apps/verify_credentials]({{< relref "methods/apps#verify_credentials" >}}):
 
 ```bash
 curl \
@@ -60,9 +76,8 @@ curl \
 	https://mastodon.example/api/v1/apps/verify_credentials
 ```
 
-If we've obtained our token and formatted our request correctly, we should see our details returned to us as an [Application]({{< relref "entities/application" >}}) entity.
+If we've obtained our token and formatted our request correctly, we should see our details returned to us as an [Application]({{< relref "entities/application" >}}) entity (without the `client_secret` property).
 
 ## What we can do with authentication {#methods}
 
 With our authenticated client application, we can view relations of an account with [GET /api/v1/accounts/:id/following]({{< relref "methods/accounts#following" >}}) and [GET /api/v1/accounts/:id/followers]({{< relref "methods/accounts#followers" >}}). Also, some instances may require authentication for methods that would otherwise be public, so if you encountered any authentication errors while playing around with public methods, then those methods should now work.
-

--- a/content/en/client/token.md
+++ b/content/en/client/token.md
@@ -31,6 +31,8 @@ In the above example, we specify the client name and website, which will be show
 - `redirect_uris` has been set to the "out of band" token generation, which means that any generated tokens will have to be copied and pasted manually. The parameter is called `redirect_uris` because it is possible to define more than one redirect URI, but when generating the token, we will need to provide a URI that is included within this list.
 - `scopes` allow us to define what permissions we can request later. However, the requested scope later can be a subset of these registered scopes. See [OAuth Scopes]({{< relref "api/oauth-scopes" >}}) for more information.
 
+You can also create applications by POSTing a JSON body to the same endpoint, as documented in [POST /api/v1/apps]({{< relref "methods/apps#create-request-example" >}}).
+
 {{< hint style="info" >}}
 As of Mastodon 4.3.0, you can make a request to [`/.well-known/oauth-authorization-server`]({{< relref "spec/oauth#authorization-server-metadata" >}}) to discover what `scopes` the server supports. In older versions of Mastodon, this endpoint will be a 404, so you should decide a "minimum version supported" for the Mastodon server that your application is interacting with.
 {{< /hint >}}

--- a/content/en/dev/overview.md
+++ b/content/en/dev/overview.md
@@ -7,7 +7,11 @@ menu:
     parent: dev
 ---
 
-Mastodon is a Ruby on Rails application with a React.js front-end.  It follows standard practices of those frameworks, so if you are already familiar with Rails or React.js, you will not find any surprises here.
+<style>
+#TableOfContents {display: none}
+</style>
+
+Mastodon is a Ruby on Rails application with a React.js front-end. It follows standard practices of those frameworks, so if you are already familiar with Rails or React.js, you will not find any surprises here.
 
 The best way of working with Mastodon in a development environment is installing all the dependencies on your system, rather than using Docker or Vagrant. You need Ruby, Node.js, PostgreSQL and Redis, which is a pretty standard set of dependencies for Rails applications.
 
@@ -19,11 +23,10 @@ An “environment” is a set of configuration values intended for a specific us
 
 The default value of `RAILS_ENV` is `development`, so you don’t need to set anything extra to run Mastodon in development mode. In fact, all of Mastodon’s configuration has correct defaults for the development environment, so you do not need an `.env` file unless you need to customize something. Here are some of the different behaviours between the development environment and the production environment:
 
-* Ruby code reloads itself when you change it, which means you don’t need to restart the Rails server process to see changes
-* All errors you encounter show stack traces in the browser, rather than being hidden behind a generic error page
-* Webpack runs continuously and re-compiles JS and CSS assets when you change any of the front-end files, and the pages automatically reload
-* Caching is disabled by default
-* An admin account with the e-mail `admin@localhost:3000` and password `mastodonadmin` is created automatically during `db:seed`
+- Ruby code reloads itself when you change it, which means you don’t need to restart the Rails server process to see changes
+- All errors you encounter show stack traces in the browser, rather than being hidden behind a generic error page
+- Webpack runs continuously and re-compiles JS and CSS assets when you change any of the front-end files, and the pages automatically reload
+- Caching is disabled by default
+- An admin account with the e-mail `admin@localhost:3000` and password `mastodonadmin` is created automatically during `db:seed`
 
 It should be noted that the Docker configuration distributed with Mastodon is optimized for the production environment, and so is an extremely bad fit for development. The Vagrant configuration, on the other hand, is meant specifically for development and not production use.
-

--- a/content/en/entities/Application.md
+++ b/content/en/entities/Application.md
@@ -17,8 +17,7 @@ aliases: [
 ```json
 {
   "name": "test app",
-  "website": null,
-  "vapid_key": "BCk-QqERU0q-CfYZjcuB6lnyyOYfJ2AifKqfeGIm7Z-HiTU5T9eTG5GxVA0_OH5mMlI4UkkDTpaZwozy0TzdZ2M="
+  "website": null
 }
 ```
 
@@ -60,8 +59,8 @@ aliases: [
 **Description:** Used for Push Streaming API. Returned with [POST /api/v1/apps]({{< relref "methods/apps#create" >}}). Equivalent to [WebPushSubscription#server_key]({{< relref "entities/WebPushSubscription#server_key" >}}) and [Instance#vapid_public_key]({{< relref "entities/Instance#vapid_public_key" >}})\
 **Type:** String\
 **Version history:**\
-2.8.0 - added
-4.3.0 - deprecated pending removal
+2.8.0 - added\
+4.3.0 - deprecated pending removal, please see [api/v2/instance]({{< relref "methods/Instance#v2">}}) for this value (`configuration.vapid.public_key`)
 
 ## See also
 

--- a/content/en/entities/Application.md
+++ b/content/en/entities/Application.md
@@ -73,9 +73,7 @@ aliases: [
 **Version history:**\
 4.3.0 - added
 
-## Deprecated attributes
-
-### `redirect_uri` {#redirect_uri}
+### `redirect_uri` {{%deprecated%}} {#redirect_uri}
 
 **Description:** The registered redirection URI(s) for your application.\
 May contain `\n` characters when multiple redirect URIs are registered.\
@@ -84,7 +82,7 @@ May contain `\n` characters when multiple redirect URIs are registered.\
 0.0.0 - added\
 4.3.0 - deprecated in favour of [`redirect_uris`]({{< relref "entities/Application#redirect_uris" >}}), since the value of this property is not a well-formed URI when multiple redirect URIs are registered
 
-### `vapid_key` {#vapid_key}
+### `vapid_key` {{%deprecated%}} {#vapid_key}
 
 **Description:** Used for Push Streaming API. Returned with [POST /api/v1/apps]({{< relref "methods/apps#create" >}}). Equivalent to [WebPushSubscription#server_key]({{< relref "entities/WebPushSubscription#server_key" >}}) and [Instance#vapid_public_key]({{< relref "entities/Instance#vapid_public_key" >}})\
 **Type:** String\

--- a/content/en/entities/Application.md
+++ b/content/en/entities/Application.md
@@ -44,21 +44,6 @@ aliases: [
 0.9.9 - added\
 3.5.1 - this property is now nullable
 
-### `client_id` {#client_id}
-
-**Description:** Client ID key, to be used for obtaining OAuth tokens\
-**Type:** String\
-**Version history:**\
-0.9.9 - added
-4.3.0 - changed to always be returned
-
-### `client_secret` {{%optional%}} {#client_secret}
-
-**Description:** Client secret key, to be used for obtaining OAuth tokens\
-**Type:** String\
-**Version history:**\
-0.9.9 - added
-
 ### `scopes` {#scopes}
 
 **Description:** The scopes for your application. This is the registered `scopes` string split on whitespace.\
@@ -90,6 +75,33 @@ May contain `\n` characters when multiple redirect URIs are registered.\
 2.8.0 - added\
 4.3.0 - deprecated pending removal, please see [api/v2/instance]({{< relref "methods/Instance#v2">}}) for this value (`configuration.vapid.public_key`)
 
+## CredentialApplication attributes {#CredentialApplication}
+
+All [Application](#attributes) attributes and the following:
+
+### `client_id` {#client_id}
+
+**Description:** Client ID key, to be used for obtaining OAuth tokens\
+**Type:** String\
+**Version history:**\
+0.9.9 - added
+4.3.0 - moved to `CredentialApplication` from `Application`
+
+### `client_secret` {#client_secret}
+
+**Description:** Client secret key, to be used for obtaining OAuth tokens\
+**Type:** String\
+**Version history:**\
+0.9.9 - added
+4.3.0 - moved to `CredentialApplication` from `Application`
+
+### `client_secret_expires_at` {#client_secret_expires_at}
+
+**Description:** When the client secret key will expire at, presently this always returns `0` indicating that OAuth Clients do not expire\
+**Type:** String\
+**Version history:**\
+4.3.0 - added
+
 ## See also
 
 {{< page-relref ref="methods/apps" caption="apps API methods" >}}
@@ -97,3 +109,5 @@ May contain `\n` characters when multiple redirect URIs are registered.\
 {{< page-relref ref="entities/Status#application" caption="Status (`application` attribute)" >}}
 
 {{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/application_serializer.rb" caption="app/serializers/rest/application_serializer.rb" >}}
+
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/credential_application_serializer.rb" caption="app/serializers/rest/credential_application_serializer.rb" >}}

--- a/content/en/entities/Application.md
+++ b/content/en/entities/Application.md
@@ -16,8 +16,14 @@ aliases: [
 
 ```json
 {
-  "name": "test app",
-  "website": null
+  "name": "Test Application",
+  "website": "https://app.example",
+  "scopes": ["read", "write", "push"],
+  "redirect_uri": "https://app.example/callback\nhttps://app.example/register",
+  "redirect_uris": [
+    "https://app.example/callback",
+    "https://app.example/register"
+  ]
 }
 ```
 
@@ -38,12 +44,13 @@ aliases: [
 0.9.9 - added\
 3.5.1 - this property is now nullable
 
-### `client_id` {{%optional%}} {#client_id}
+### `client_id` {#client_id}
 
 **Description:** Client ID key, to be used for obtaining OAuth tokens\
 **Type:** String\
 **Version history:**\
 0.9.9 - added
+4.3.0 - changed to always be returned
 
 ### `client_secret` {{%optional%}} {#client_secret}
 
@@ -52,7 +59,30 @@ aliases: [
 **Version history:**\
 0.9.9 - added
 
+### `scopes` {#scopes}
+
+**Description:** The scopes for your application. This is the registered `scopes` string split on whitespace.\
+**Type:** Array of Strings\
+**Version history:**\
+4.3.0 - added
+
+### `redirect_uris` {#redirect_uris}
+
+**Description:** The registered redirection URI(s) for your application.\
+**Type:** Array of String (URLs or `"urn:ietf:wg:oauth:2.0:oob"` as values)\
+**Version history:**\
+4.3.0 - added
+
 ## Deprecated attributes
+
+### `redirect_uri` {#redirect_uri}
+
+**Description:** The registered redirection URI(s) for your application.\
+May contain `\n` characters when multiple redirect URIs are registered.\
+**Type:** String\
+**Version history:**\
+0.0.0 - added\
+4.3.0 - deprecated in favour of [`redirect_uris`]({{< relref "entities/Application#redirect_uris" >}}), since the value of this property is not a well-formed URI when multiple redirect URIs are registered
 
 ### `vapid_key` {#vapid_key}
 

--- a/content/en/entities/MediaAttachment.md
+++ b/content/en/entities/MediaAttachment.md
@@ -223,9 +223,7 @@ More importantly, there may be another topl-level `focus` Hash object on images 
 **Version history:**\
 2.8.1 - added
 
-## Deprecated attributes
-
-### `text_url` {#text_url}
+### `text_url` {{%removed%}} {#text_url}
 
 **Description:** A shorter URL for the attachment.\
 **Type:** String (URL)\

--- a/content/en/entities/Search.md
+++ b/content/en/entities/Search.md
@@ -109,7 +109,7 @@ Truncated sample search for q=cats limit=2
 **Version history:**\
 1.1.0 - added\
 2.4.1 - v1/search deprecated because it returns Array of String. v2/search added which returns Array of Tag.\
-3.0.0 - v1 removed
+3.0.0 - v1/search removed
 
 ## See also
 

--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -157,9 +157,10 @@ GET /api/v1/accounts/verify_credentials HTTP/1.1
 Test to make sure that the user token works.
 
 **Returns:** [CredentialAccount]({{< relref "entities/Account#CredentialAccount">}})\
-**OAuth**: User token + `read:accounts`\
+**OAuth:** User token + `profile` or `read:accounts`\
 **Version history:**\
 0.0.0 - added
+4.3.0 - added `profile` scope
 
 #### Request
 

--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -25,6 +25,8 @@ POST /api/v1/accounts HTTP/1.1
 
 Creates a user and account records. Returns an account access token for the app that initiated the request. The app should save this token for later, and should wait for the user to confirm their account by clicking a link in their email inbox.
 
+A relationship between the OAuth Application and created user account is stored.
+
 **Returns:** [Token]({{< relref "entities/token" >}})\
 **OAuth:** App token + `write:accounts`\
 **Version history:**\

--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -39,7 +39,7 @@ A relationship between the OAuth Application and created user account is stored.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <app token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <app_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -169,7 +169,7 @@ Test to make sure that the user token works.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 
@@ -326,7 +326,7 @@ Update the user's display and preferences.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -560,7 +560,7 @@ View information about a profile.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -749,7 +749,7 @@ id[]
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -835,7 +835,7 @@ Statuses posted to the given account.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -943,7 +943,7 @@ Accounts which follow the given account, if network is not hidden by the account
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -1049,7 +1049,7 @@ Accounts which the given account is following, if network is not hidden by the a
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -1152,7 +1152,7 @@ Tags featured by this account.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1192,7 +1192,7 @@ User lists that you have added this account to.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1283,7 +1283,7 @@ Follow the given account. Can also be used to update whether to show reblogs or 
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -1363,7 +1363,7 @@ Unfollow the given account.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1431,7 +1431,7 @@ Remove the given account from your followers.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1500,7 +1500,7 @@ Block the given account. Clients should filter statuses from this account if rec
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1569,7 +1569,7 @@ Unblock the given account.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1639,7 +1639,7 @@ Mute the given account. Clients should filter statuses and notifications from th
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -1716,7 +1716,7 @@ Unmute the given account.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1785,7 +1785,7 @@ Add the given account to the user's featured profiles. (Featured profiles are cu
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1883,7 +1883,7 @@ Remove the given account from the user's featured profiles.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1951,7 +1951,7 @@ Sets a private note on a user.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -2041,7 +2041,7 @@ Find out whether a given account is followed, blocked, muted, etc.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -2128,7 +2128,7 @@ Obtain a list of all accounts that follow a given account, filtered for accounts
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -2207,7 +2207,7 @@ Search for matching accounts by username or display name.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 

--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -2327,7 +2327,7 @@ Username or address does not map to an account
 
 ---
 
-## (DEPRECATED) Identity proofs {#identity_proofs}
+## Identity proofs {{%deprecated%}} {#identity_proofs}
 
 ```http
 GET /api/v1/accounts/:id/identity_proofs HTTP/1.1

--- a/content/en/methods/admin/accounts.md
+++ b/content/en/methods/admin/accounts.md
@@ -37,7 +37,7 @@ View all accounts, optionally matching certain criteria for filtering, up to 100
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -199,7 +199,7 @@ View all accounts, optionally matching certain criteria for filtering, up to 100
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -331,7 +331,7 @@ View admin-level information about the given account.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -427,7 +427,7 @@ Approve the given local account if it is currently pending approval.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -493,7 +493,7 @@ Reject the given local account if it is currently pending approval.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -597,7 +597,7 @@ Permanently delete data for a suspended account.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -704,7 +704,7 @@ Perform an action against an account and log this action in the moderation histo
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -789,7 +789,7 @@ Re-enable a local account whose login is currently disabled.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -855,7 +855,7 @@ Unsilence an account if it is currently silenced.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -921,7 +921,7 @@ Unsuspend a currently suspended account.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -987,7 +987,7 @@ Stops marking an account's posts as sensitive, if it was previously flagged as s
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/admin/canonical_email_blocks.md
+++ b/content/en/methods/admin/canonical_email_blocks.md
@@ -33,7 +33,7 @@ GET /api/v1/admin/canonical_email_blocks HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -102,7 +102,7 @@ GET /api/v1/admin/canonical_email_blocks/:id HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -155,7 +155,7 @@ Canoniocalize and hash an email address.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -209,7 +209,7 @@ POST /api/v1/admin/canonical_email_blocks HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -275,7 +275,7 @@ DELETE /api/v1/admin/canonical_email_blocks/:id HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/admin/dimensions.md
+++ b/content/en/methods/admin/dimensions.md
@@ -36,7 +36,7 @@ Obtain information about popularity of certain accounts, servers, languages, etc
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 

--- a/content/en/methods/admin/domain_allows.md
+++ b/content/en/methods/admin/domain_allows.md
@@ -35,7 +35,7 @@ Show information about all allowed domains.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -109,7 +109,7 @@ Show information about a single allowed domain.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -163,7 +163,7 @@ Add a domain to the list of domains allowed to federate, to be used when the ins
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -229,7 +229,7 @@ Delete a domain from the allowed domains list.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/admin/domain_blocks.md
+++ b/content/en/methods/admin/domain_blocks.md
@@ -35,7 +35,7 @@ Show information about all blocked domains.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -112,7 +112,7 @@ Show information about a single blocked domain.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -173,7 +173,7 @@ Add a domain to the list of domains blocked from federating.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -286,7 +286,7 @@ Change parameters for an existing domain block.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -368,7 +368,7 @@ Lift a block against a domain.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/admin/email_domain_blocks.md
+++ b/content/en/methods/admin/email_domain_blocks.md
@@ -35,7 +35,7 @@ Show information about all email domains blocked from signing up.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -136,7 +136,7 @@ Show information about a single email domain that is blocked from signups.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -227,7 +227,7 @@ Add a domain to the list of email domains blocked from signups.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -338,7 +338,7 @@ Lift a block against an email domain.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/admin/ip_blocks.md
+++ b/content/en/methods/admin/ip_blocks.md
@@ -35,7 +35,7 @@ Show information about all blocked IP ranges.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -109,7 +109,7 @@ Show information about a single IP block.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -166,7 +166,7 @@ Add an IP address range to the list of IP blocks.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -244,7 +244,7 @@ Change parameters for an existing IP block.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -312,7 +312,7 @@ Lift a block against an IP range.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/admin/measures.md
+++ b/content/en/methods/admin/measures.md
@@ -36,7 +36,7 @@ Obtain statistical measures for your server.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 

--- a/content/en/methods/admin/reports.md
+++ b/content/en/methods/admin/reports.md
@@ -36,7 +36,7 @@ View information about all reports.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -153,7 +153,7 @@ GET /api/v1/admin/reports/:id HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -253,7 +253,7 @@ Change metadata for a report.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -316,7 +316,7 @@ Claim the handling of this report to yourself.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -391,7 +391,7 @@ Unassign a report so that someone else can claim it.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -453,7 +453,7 @@ Mark a report as resolved with no further action taken.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -510,7 +510,7 @@ Reopen a currently closed report, if it is closed.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/admin/retention.md
+++ b/content/en/methods/admin/retention.md
@@ -36,7 +36,7 @@ Generate a retention data report for a given time period and bucket.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 

--- a/content/en/methods/admin/trends.md
+++ b/content/en/methods/admin/trends.md
@@ -35,7 +35,7 @@ Links that have been shared more than others, including unapproved and unreviewe
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -128,7 +128,7 @@ Statuses that have been interacted with more than others, including unapproved a
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -187,7 +187,7 @@ Tags that are being used more frequently within the past week, including unappro
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/announcements.md
+++ b/content/en/methods/announcements.md
@@ -36,7 +36,7 @@ See all currently active announcements set by admins.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -125,7 +125,7 @@ Allows a user to mark the announcement as read.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -181,7 +181,7 @@ React to an announcement with an emoji.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -246,7 +246,7 @@ Undo a react emoji to an announcement.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/apps.md
+++ b/content/en/methods/apps.md
@@ -22,7 +22,14 @@ POST /api/v1/apps HTTP/1.1
 
 Create a new application to obtain OAuth2 credentials.
 
-**Returns:** [Application]({{< relref "entities/Application" >}})\
+{{< hint style="danger" >}}
+In Mastodon prior to 4.3, OAuth Applications could be "vacuumed" and removed from the database under certain conditions, meaning your Application's `client_id` and `client_secret` would not be recognised by the Mastodon server.\
+This automated removal of applications was removed in Mastodon 4.3\
+\
+A workaround for Mastodon versions older than 4.3 was to register your application, and then immediately request a [Client Credential]({{< relref "client/Token#flow" >}}) token, which would permanently ensure your application always had an active access token and would not be removed.
+{{< /hint >}}
+
+**Returns:** [CredentialApplication]({{< relref "entities/Application#CredentialApplication" >}})\
 **OAuth:** Public\
 **Version history:**\
 0.0.0 - added\
@@ -30,7 +37,8 @@ Create a new application to obtain OAuth2 credentials.
 4.3.0 - deprecated `vapid_key`, please see [api/v2/instance]({{< relref "methods/Instance#v2">}})\
 4.3.0 - added support for multiple `redirect_uris` in Form data parameters\
 4.3.0 - added `redirect_uris` response property\
-4.3.0 - deprecated `redirect_uri` response property, since this can be a non-URI if multiple `redirect_uris` are registered
+4.3.0 - deprecated `redirect_uri` response property, since this can be a non-URI if multiple `redirect_uris` are registered, use `redirect_uris` instead\
+4.3.0 - changed entity type from [Application]({{< relref "entities/Application">}}) to [CredentialApplication]({{< relref "entities/Application#CredentialApplication">}})
 
 #### Request
 
@@ -127,14 +135,14 @@ GET /api/v1/apps/verify_credentials HTTP/1.1
 
 Confirm that the app's OAuth2 credentials work.
 
-**Returns:** [Application]({{< relref "entities/application" >}}), but without `client_secret`\
-**OAuth level:** App token\
+**Returns:** [Application]({{< relref "entities/application" >}})\
+**OAuth:** App token\
 **Version history:**\
 2.0.0 - added\
 2.7.2 - now returns `vapid_key`\
 4.3.0 - deprecated `vapid_key`, please see [api/v2/instance]({{< relref "methods/Instance#v2">}})\
-4.3.0 - removed the need to have `read` scope to access this API, now any valid App token can be used
-4.3.0 - added `client_id`, `scopes` and `redirect_uris` properties
+4.3.0 - removed needing `read` scope to access this API, now any valid App token can be used\
+4.3.0 - added `scopes` and `redirect_uris` properties
 
 #### Request
 
@@ -157,8 +165,7 @@ If the Authorization header was provided with a valid token, you should see your
   "redirect_uris": [
     "https://app.example/callback",
     "https://app.example/register"
-  ],
-  "client_id": "TWhM-tNSuncnqN7DBJmoyeLnk6K3iJJ71KKXxgL1hPM"
+  ]
 }
 ```
 

--- a/content/en/methods/apps.md
+++ b/content/en/methods/apps.md
@@ -29,6 +29,12 @@ This automated removal of applications was removed in Mastodon 4.3\
 A workaround for Mastodon versions older than 4.3 was to register your application, and then immediately request a [Client Credential]({{< relref "client/Token#flow" >}}) token, which would permanently ensure your application always had an active access token and would not be removed.
 {{< /hint >}}
 
+{{< hint style="info" >}}
+At present, Mastodon only supports provisioning confidential clients, i.e., you will always receive a `client_secret` and `client_secret_expires_at` attributes in the [CredentialApplication]({{< relref "entities/Application#CredentialApplication" >}}) entity.\
+\
+For more information see: [OAuth 2 client types]({{< relref "spec/oauth#client-types" >}})
+{{< /hint >}}
+
 **Returns:** [CredentialApplication]({{< relref "entities/Application#CredentialApplication" >}})\
 **OAuth:** Public\
 **Version history:**\

--- a/content/en/methods/apps.md
+++ b/content/en/methods/apps.md
@@ -61,8 +61,7 @@ Store the `client_id` and `client_secret` in your cache, as these will be used t
   "website": null,
   "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
   "client_id": "TWhM-tNSuncnqN7DBJmoyeLnk6K3iJJ71KKXxgL1hPM",
-  "client_secret": "ZEaFUFmF0umgBX1qKJDjaU99Q31lDkOU8NutzTOoliw",
-  "vapid_key": "BCk-QqERU0q-CfYZjcuB6lnyyOYfJ2AifKqfeGIm7Z-HiTU5T9eTG5GxVA0_OH5mMlI4UkkDTpaZwozy0TzdZ2M="
+  "client_secret": "ZEaFUFmF0umgBX1qKJDjaU99Q31lDkOU8NutzTOoliw"
 }
 ```
 
@@ -109,8 +108,7 @@ If the Authorization header was provided with a valid token, you should see your
 ```json
 {
   "name": "test app",
-  "website": null,
-  "vapid_key": "BCk-QqERU0q-CfYZjcuB6lnyyOYfJ2AifKqfeGIm7Z-HiTU5T9eTG5GxVA0_OH5mMlI4UkkDTpaZwozy0TzdZ2M="
+  "website": null
 }
 ```
 

--- a/content/en/methods/apps.md
+++ b/content/en/methods/apps.md
@@ -29,9 +29,11 @@ Create a new application to obtain OAuth2 credentials.
 **OAuth:** Public\
 **Version history:**\
 0.0.0 - added\
-2.7.2 - now returns `vapid_key`
+2.7.2 - now returns `vapid_key`\
+4.3.0 - deprecated `vapid_key`, please see [api/v2/instance]({{< relref "methods/Instance#v2">}})
 
 #### Request
+
 ##### Form data parameters
 
 client_name
@@ -47,6 +49,7 @@ website
 : String. A URL to the homepage of your app
 
 #### Response
+
 ##### 200: OK
 
 Store the `client_id` and `client_secret` in your cache, as these will be used to obtain OAuth tokens.
@@ -87,7 +90,8 @@ Confirm that the app's OAuth2 credentials work.
 **OAuth level:** App token + `read`\
 **Version history:**\
 2.0.0 - added\
-2.7.2 - now returns `vapid_key`
+2.7.2 - now returns `vapid_key`\
+4.3.0 - deprecated `vapid_key`, please see [api/v2/instance]({{< relref "methods/Instance#v2">}})
 
 #### Request
 
@@ -97,6 +101,7 @@ Authorization
 : {{<required>}} Provide this header with `Bearer <app token>` to gain authorized access to this API method.
 
 #### Response
+
 ##### 200: OK
 
 If the Authorization header was provided with a valid token, you should see your app returned as an Application entity.

--- a/content/en/methods/apps.md
+++ b/content/en/methods/apps.md
@@ -46,7 +46,7 @@ For more information see: [OAuth 2 client types]({{< relref "spec/oauth#client-t
 4.3.0 - deprecated `redirect_uri` response property, since this can be a non-URI if multiple `redirect_uris` are registered, use `redirect_uris` instead\
 4.3.0 - changed entity type from [Application]({{< relref "entities/Application">}}) to [CredentialApplication]({{< relref "entities/Application#CredentialApplication">}})
 
-#### Request
+#### Request {#create-request-example}
 
 Example request:
 

--- a/content/en/methods/apps.md
+++ b/content/en/methods/apps.md
@@ -155,7 +155,7 @@ Confirm that the app's OAuth2 credentials work.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <app token>` to gain authorized access to this API method. `<app token>` may be either a `client_credential` or `access_token` returned from [`/oauth/token`]({{< relref "methods/oauth#token" >}})
+: {{<required>}} Provide this header with `Bearer <app_token>` to gain authorized access to this API method. `<app_token>` may be either a `client_credential` or `access_token` returned from [`/oauth/token`]({{< relref "methods/oauth#token" >}})
 
 #### Response
 

--- a/content/en/methods/blocks.md
+++ b/content/en/methods/blocks.md
@@ -35,7 +35,7 @@ GET /api/v1/blocks HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 

--- a/content/en/methods/bookmarks.md
+++ b/content/en/methods/bookmarks.md
@@ -36,7 +36,7 @@ Statuses the user has bookmarked.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 

--- a/content/en/methods/conversations.md
+++ b/content/en/methods/conversations.md
@@ -37,7 +37,7 @@ GET /api/v1/conversations HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -143,7 +143,7 @@ Removes a conversation from your list of conversations.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -195,7 +195,7 @@ POST /api/v1/conversations/:id/read HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/domain_blocks.md
+++ b/content/en/methods/domain_blocks.md
@@ -35,7 +35,7 @@ View domains the user has blocked.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -100,7 +100,7 @@ Block a domain to:
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -162,7 +162,7 @@ Remove a domain block, if it exists in the user's array of blocked domains.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 

--- a/content/en/methods/emails.md
+++ b/content/en/methods/emails.md
@@ -35,7 +35,7 @@ Resend a new confirmation email. If an email is provided, updates the unconfirme
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 

--- a/content/en/methods/endorsements.md
+++ b/content/en/methods/endorsements.md
@@ -36,7 +36,7 @@ Accounts that the user is currently featuring on their profile.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 

--- a/content/en/methods/favourites.md
+++ b/content/en/methods/favourites.md
@@ -37,7 +37,7 @@ Statuses the user has favourited.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 

--- a/content/en/methods/featured_tags.md
+++ b/content/en/methods/featured_tags.md
@@ -35,7 +35,7 @@ List all hashtags featured on your profile.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -81,7 +81,7 @@ Promote a hashtag on your profile.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -148,7 +148,7 @@ Stop promoting a hashtag on your profile.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -198,7 +198,7 @@ Shows up to 10 recently-used tags.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/filters.md
+++ b/content/en/methods/filters.md
@@ -1251,7 +1251,7 @@ Replaces a filter's parameters in-place.
 **Version history:**\
 2.4.3 - added\
 3.1.0 - added `account` context to filter in profile views\
-4.0.0 - deprecated. or compatibility purposes, now returns a V1::Filter representing one FilterKeyword (with the `keyword` being presented in the `phrase` attribute). This method will return an error if you attempt to change `expires_in`, `irreversible`, or `context` for a filter with multiple keywords. Changing `phrase` and `whole_word` is always safe.
+4.0.0 - deprecated. For compatibility purposes, now returns a V1::Filter representing one FilterKeyword (with the `keyword` being presented in the `phrase` attribute). This method will return an error if you attempt to change `expires_in`, `irreversible`, or `context` for a filter with multiple keywords. Changing `phrase` and `whole_word` is always safe.
 
 #### Request
 

--- a/content/en/methods/filters.md
+++ b/content/en/methods/filters.md
@@ -38,7 +38,7 @@ Obtain a list of all filter groups for the current user.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -111,7 +111,7 @@ Obtain a single filter group owned by the current user.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -186,7 +186,7 @@ Create a filter group with the given parameters.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -310,7 +310,7 @@ Update a filter group with the given parameters.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -416,7 +416,7 @@ Delete a filter group with the given id.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -472,7 +472,7 @@ List all keywords attached to the current filter group.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -533,7 +533,7 @@ Add the given keyword to the specified filter group
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -609,7 +609,7 @@ Get one filter keyword by the given id.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -667,7 +667,7 @@ Update the given filter keyword.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -745,7 +745,7 @@ Deletes the given filter keyword.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -801,7 +801,7 @@ Obtain a list of all status filters within this filter group.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -861,7 +861,7 @@ Add a status filter to the current filter group.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -925,7 +925,7 @@ Obtain a single status filter.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -982,7 +982,7 @@ Remove a status filter from the current filter group.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1037,7 +1037,7 @@ GET /api/v1/filters HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1108,7 +1108,7 @@ GET /api/v1/filters/:id HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1168,7 +1168,7 @@ POST /api/v1/filters HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -1263,7 +1263,7 @@ Replaces a filter's parameters in-place.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -1365,7 +1365,7 @@ DELETE /api/v1/filters/:id HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/filters.md
+++ b/content/en/methods/filters.md
@@ -1021,7 +1021,7 @@ Prior to Mastodon 4.0, matching filters was done client-size and filters could o
 
 ---
 
-### View your filters {#get-v1}
+### View your filters {{%deprecated%}} {#get-v1}
 
 ```http
 GET /api/v1/filters HTTP/1.1
@@ -1086,7 +1086,7 @@ Invalid or missing Authorization header.
 
 ---
 
-### View a single filter {#get-one-v1}
+### View a single filter {{%deprecated%}} {#get-one-v1}
 
 ```http
 GET /api/v1/filters/:id HTTP/1.1
@@ -1151,7 +1151,7 @@ Filter ID does not exist, or is not owned by you
 
 ---
 
-### Create a filter {#create-v1}
+### Create a filter {{%deprecated%}} {#create-v1}
 
 ```http
 POST /api/v1/filters HTTP/1.1
@@ -1238,7 +1238,7 @@ If context is not provided properly:
 
 ---
 
-### Update a filter {#update-v1}
+### Update a filter {{%deprecated%}} {#update-v1}
 
 ```http
 PUT /api/v1/filters/:id HTTP/1.1
@@ -1343,7 +1343,7 @@ If context is not provided properly:
 
 ---
 
-### Remove a filter {#delete-v1}
+### Remove a filter {{%deprecated%}} {#delete-v1}
 
 ```http
 DELETE /api/v1/filters/:id HTTP/1.1

--- a/content/en/methods/follow_requests.md
+++ b/content/en/methods/follow_requests.md
@@ -34,7 +34,7 @@ GET /api/v1/follow_requests HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -111,7 +111,7 @@ POST /api/v1/follow_requests/:account_id/authorize HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -178,7 +178,7 @@ POST /api/v1/follow_requests/:account_id/reject HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/followed_tags.md
+++ b/content/en/methods/followed_tags.md
@@ -36,7 +36,7 @@ List your followed hashtags.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 

--- a/content/en/methods/instance.md
+++ b/content/en/methods/instance.md
@@ -28,7 +28,8 @@ Obtain general information about the server.
 **Returns:** [Instance]({{< relref "entities/Instance" >}})\
 **OAuth:** Public\
 **Version history:**\
-4.0.0 - added
+4.0.0 - added\
+4.3.0 - added `configuration.vapid.public_key`
 
 #### Response
 
@@ -204,7 +205,6 @@ Obtain general information about the server.
 }
 ```
 
-
 ---
 
 ## List of connected domains {#peers}
@@ -270,6 +270,7 @@ Authorization
 : Provide this header with `Bearer <user token>` to gain authorized access to this API method.
 
 #### Response
+
 ##### 200: OK
 
 Each hash in the array will contain the following attributes:
@@ -377,7 +378,6 @@ If the instance is in whitelist mode and the Authorization header is missing or 
 
 ## List of rules {#rules}
 
-
 ```http
 GET /api/v1/instance/rules HTTP/1.1
 ```
@@ -390,6 +390,7 @@ Rules that the users of this service should follow.
 3.4.0 - added
 
 #### Response
+
 ##### 200: OK
 
 ```json
@@ -444,6 +445,7 @@ Authorization
 : Provide this header with `Bearer <user token>` to gain authorized access to this API method.
 
 #### Response
+
 ##### 200: OK
 
 The complete list of domains blocked by this instance
@@ -499,6 +501,7 @@ Obtain an extended description of this server
 4.0.0 - added
 
 #### Response
+
 ##### 200: OK
 
 ```json
@@ -524,6 +527,7 @@ Translation language pairs supported by the translation engine used by the serve
 4.2.0 - added
 
 #### Response
+
 ##### 200: OK
 
 All source and target language pairs supported by the server.
@@ -546,7 +550,7 @@ In the following sample response showing support for translating a status writte
 GET /api/v1/instance HTTP/1.1
 ```
 
-Obtain general information about the server.
+Obtain general information about the server. See [api/v2/instance]({{< relref "methods/Instance#v2">}}) instead.
 
 **Returns:** [V1::Instance]({{< relref "entities/V1_Instance" >}})\
 **OAuth:** Public\

--- a/content/en/methods/instance.md
+++ b/content/en/methods/instance.md
@@ -545,7 +545,7 @@ In the following sample response showing support for translating a status writte
 
 ---
 
-## (DEPRECATED) View server information (V1) {#v1}
+## View server information (v1) {{%deprecated%}} {#v1}
 
 ```http
 GET /api/v1/instance HTTP/1.1

--- a/content/en/methods/instance.md
+++ b/content/en/methods/instance.md
@@ -226,7 +226,7 @@ Domains that this instance is aware of.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 
@@ -267,7 +267,7 @@ Instance activity over the last 3 months, binned weekly.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 
@@ -442,7 +442,7 @@ Obtain a list of domains that have been blocked.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 

--- a/content/en/methods/instance.md
+++ b/content/en/methods/instance.md
@@ -453,17 +453,17 @@ The complete list of domains blocked by this instance
 ```json
 [
   {
-    "domain":"birb.elfenban.de",
-    "digest":"5d2c6e02a0cced8fb05f32626437e3d23096480b47efbba659b6d9e80c85d280",
-    "severity":"suspend",
-    "comment":"Third-party bots"
+    "domain": "birb.elfenban.de",
+    "digest": "5d2c6e02a0cced8fb05f32626437e3d23096480b47efbba659b6d9e80c85d280",
+    "severity": "suspend",
+    "comment": "Third-party bots"
   },
   {
-    "domain":"birdbots.leptonics.com",
-    "digest":"ce019d8d32cce8e369ac4367f4dc232103e6f489fbdd247fb99f9c8a646078a4",
-    "severity":"suspend",
-    "comment":"Third-party bots"
-  },
+    "domain": "birdbots.leptonics.com",
+    "digest": "ce019d8d32cce8e369ac4367f4dc232103e6f489fbdd247fb99f9c8a646078a4",
+    "severity": "suspend",
+    "comment": "Third-party bots"
+  }
   // ...
 ]
 ```
@@ -483,6 +483,7 @@ Invalid or missing Authorization header, if the admin has chosen to show domain 
 The admin has chosen to show domain blocks to no one. The response body is empty; only the HTTP 404 error code is relevant.
 
 ```text
+
 ```
 
 ---
@@ -506,8 +507,8 @@ Obtain an extended description of this server
 
 ```json
 {
-  "updated_at":"2022-11-03T04:09:07Z",
-  "content":"<p>For inquiries not related specifically to the operation of this server, such as press inquiries, please contact <a href=\"mailto:press@joinmastodon.org\">press@joinmastodon.org</a>.</p>\n\n<h2>Funding</h2>\n\n<p>This server is crowdfunded by <a href=\"https://patreon.com/mastodon\">Patreon donations</a>. For a list of sponsors, see <a href=\"https://joinmastodon.org/sponsors\">joinmastodon.org</a>.</p>\n\n<h2>Reporting and moderation</h2>\n\n<p>When reporting accounts, please make sure to include at least a few posts that show rule-breaking behaviour, when applicable. If there is any additional context that might help make a decision, please also include it in the comment. This is especially important when the content is in a language nobody on the moderation team speaks.</p>\n\n<p>We usually handle reports within 24 hours. Please mind that you are not notified when a report you have made has led to a punitive action, and that not all punitive actions are externally visible. For first time offenses, we may opt to delete offending content, escalating to harsher measures on repeat offenses.</p>\n\n<h2>Impressum</h2>\n\n<p>Mastodon gGmbH<br>\nMühlenstraße 8a<br>\n14167 Berlin<br>\nGermany</p>\n\n<p>E-Mail-Adresse: hello@joinmastodon.org</p>\n\n<p>Vertretungsberechtigt: Eugen Rochko (Geschäftsführer)</p>\n\n<p>Umsatzsteuer Identifikationsnummer (USt-ID): DE344258260</p>\n\n<p>Handelsregister<br>\nGeführt bei: Amtsgericht Charlottenburg<br>\nNummer: HRB 230086 B</p>\n"
+  "updated_at": "2022-11-03T04:09:07Z",
+  "content": "<p>For inquiries not related specifically to the operation of this server, such as press inquiries, please contact <a href=\"mailto:press@joinmastodon.org\">press@joinmastodon.org</a>.</p>\n\n<h2>Funding</h2>\n\n<p>This server is crowdfunded by <a href=\"https://patreon.com/mastodon\">Patreon donations</a>. For a list of sponsors, see <a href=\"https://joinmastodon.org/sponsors\">joinmastodon.org</a>.</p>\n\n<h2>Reporting and moderation</h2>\n\n<p>When reporting accounts, please make sure to include at least a few posts that show rule-breaking behaviour, when applicable. If there is any additional context that might help make a decision, please also include it in the comment. This is especially important when the content is in a language nobody on the moderation team speaks.</p>\n\n<p>We usually handle reports within 24 hours. Please mind that you are not notified when a report you have made has led to a punitive action, and that not all punitive actions are externally visible. For first time offenses, we may opt to delete offending content, escalating to harsher measures on repeat offenses.</p>\n\n<h2>Impressum</h2>\n\n<p>Mastodon gGmbH<br>\nMühlenstraße 8a<br>\n14167 Berlin<br>\nGermany</p>\n\n<p>E-Mail-Adresse: hello@joinmastodon.org</p>\n\n<p>Vertretungsberechtigt: Eugen Rochko (Geschäftsführer)</p>\n\n<p>Umsatzsteuer Identifikationsnummer (USt-ID): DE344258260</p>\n\n<p>Handelsregister<br>\nGeführt bei: Amtsgericht Charlottenburg<br>\nNummer: HRB 230086 B</p>\n"
 }
 ```
 
@@ -568,35 +569,33 @@ Obtain general information about the server. See [api/v2/instance]({{< relref "m
 
 ```json
 {
-  "uri":"mastodon.social",
-  "title":"Mastodon",
-  "short_description":"The original server operated by the Mastodon gGmbH non-profit",
-  "description":"",
-  "email":"staff@mastodon.social",
-  "version":"3.5.3",
-  "urls":{
-    "streaming_api":"wss://mastodon.social"
+  "uri": "mastodon.social",
+  "title": "Mastodon",
+  "short_description": "The original server operated by the Mastodon gGmbH non-profit",
+  "description": "",
+  "email": "staff@mastodon.social",
+  "version": "3.5.3",
+  "urls": {
+    "streaming_api": "wss://mastodon.social"
   },
-  "stats":{
-    "user_count":812303,
-    "status_count":38151616,
-    "domain_count":25255
+  "stats": {
+    "user_count": 812303,
+    "status_count": 38151616,
+    "domain_count": 25255
   },
-  "thumbnail":"https://files.mastodon.social/site_uploads/files/000/000/001/original/vlcsnap-2018-08-27-16h43m11s127.png",
-  "languages":[
-    "en"
-  ],
-  "registrations":false,
-  "approval_required":false,
-  "invites_enabled":true,
-  "configuration":{
-    "statuses":{
-      "max_characters":500,
-      "max_media_attachments":4,
-      "characters_reserved_per_url":23
+  "thumbnail": "https://files.mastodon.social/site_uploads/files/000/000/001/original/vlcsnap-2018-08-27-16h43m11s127.png",
+  "languages": ["en"],
+  "registrations": false,
+  "approval_required": false,
+  "invites_enabled": true,
+  "configuration": {
+    "statuses": {
+      "max_characters": 500,
+      "max_media_attachments": 4,
+      "characters_reserved_per_url": 23
     },
-    "media_attachments":{
-      "supported_mime_types":[
+    "media_attachments": {
+      "supported_mime_types": [
         "image/jpeg",
         "image/png",
         "image/gif",
@@ -623,17 +622,17 @@ Obtain general information about the server. See [api/v2/instance]({{< relref "m
         "audio/3gpp",
         "video/x-ms-asf"
       ],
-      "image_size_limit":10485760,
-      "image_matrix_limit":16777216,
-      "video_size_limit":41943040,
-      "video_frame_rate_limit":60,
-      "video_matrix_limit":2304000
+      "image_size_limit": 10485760,
+      "image_matrix_limit": 16777216,
+      "video_size_limit": 41943040,
+      "video_frame_rate_limit": 60,
+      "video_matrix_limit": 2304000
     },
-    "polls":{
-      "max_options":4,
-      "max_characters_per_option":50,
-      "min_expiration":300,
-      "max_expiration":2629746
+    "polls": {
+      "max_options": 4,
+      "max_characters_per_option": 50,
+      "min_expiration": 300,
+      "max_expiration": 2629746
     }
   },
   "contact_account":{
@@ -661,36 +660,36 @@ Obtain general information about the server. See [api/v2/instance]({{< relref "m
     ],
     "fields":[
       {
-        "name":"Patreon",
-        "value":"\u003ca href=\"https://www.patreon.com/mastodon\" target=\"_blank\" rel=\"nofollow noopener noreferrer me\"\u003e\u003cspan class=\"invisible\"\u003ehttps://www.\u003c/span\u003e\u003cspan class=\"\"\u003epatreon.com/mastodon\u003c/span\u003e\u003cspan class=\"invisible\"\u003e\u003c/span\u003e\u003c/a\u003e",
-        "verified_at":null
+        "name": "Patreon",
+        "value": "\u003ca href=\"https://www.patreon.com/mastodon\" target=\"_blank\" rel=\"nofollow noopener noreferrer me\"\u003e\u003cspan class=\"invisible\"\u003ehttps://www.\u003c/span\u003e\u003cspan class=\"\"\u003epatreon.com/mastodon\u003c/span\u003e\u003cspan class=\"invisible\"\u003e\u003c/span\u003e\u003c/a\u003e",
+        "verified_at": null
       }
     ]
   },
-  "rules":[
+  "rules": [
     {
-      "id":"1",
-      "text":"Sexually explicit or violent media must be marked as sensitive when posting"
+      "id": "1",
+      "text": "Sexually explicit or violent media must be marked as sensitive when posting"
     },
     {
-      "id":"2",
-      "text":"No racism, sexism, homophobia, transphobia, xenophobia, or casteism"
+      "id": "2",
+      "text": "No racism, sexism, homophobia, transphobia, xenophobia, or casteism"
     },
     {
-      "id":"3",
-      "text":"No incitement of violence or promotion of violent ideologies"
+      "id": "3",
+      "text": "No incitement of violence or promotion of violent ideologies"
     },
     {
-      "id":"4",
-      "text":"No harassment, dogpiling or doxxing of other users"
+      "id": "4",
+      "text": "No harassment, dogpiling or doxxing of other users"
     },
     {
-      "id":"5",
-      "text":"No content illegal in Germany"
+      "id": "5",
+      "text": "No content illegal in Germany"
     },
     {
-      "id":"7",
-      "text":"Do not share intentionally false or misleading information"
+      "id": "7",
+      "text": "Do not share intentionally false or misleading information"
     }
   ]
 }

--- a/content/en/methods/lists.md
+++ b/content/en/methods/lists.md
@@ -38,7 +38,7 @@ Fetch all lists that the user owns.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -97,7 +97,7 @@ Fetch the list with the given ID. Used for verifying the title of a list, and wh
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -154,7 +154,7 @@ Create a new list.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -236,7 +236,7 @@ Change the title of a list, or which replies to show.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -314,7 +314,7 @@ DELETE /api/v1/lists/:id HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -370,7 +370,7 @@ GET /api/v1/lists/:id/accounts HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -476,7 +476,7 @@ Add accounts to the given list. Note that the user must be following these accou
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -545,7 +545,7 @@ Remove accounts from the given list.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 

--- a/content/en/methods/markers.md
+++ b/content/en/methods/markers.md
@@ -36,7 +36,7 @@ Get current positions in timelines.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -93,7 +93,7 @@ Save current position in timeline.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 

--- a/content/en/methods/media.md
+++ b/content/en/methods/media.md
@@ -366,7 +366,7 @@ Attachment is not owned by you or does not exist
 
 ---
 
-## (DEPRECATED) Upload media as an attachment {#v1}
+## Upload media as an attachment (v1) {{%deprecated%}} {#v1}
 
 ```http
 POST /api/v1/media HTTP/1.1

--- a/content/en/methods/media.md
+++ b/content/en/methods/media.md
@@ -39,7 +39,7 @@ Creates a media attachment to be used with a new status. The full sized media wi
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -182,7 +182,7 @@ Get a media attachment, before it is attached to a status and posted, but after 
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -286,7 +286,7 @@ Update a MediaAttachment's parameters, before it is attached to a status and pos
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -386,7 +386,7 @@ Creates an attachment to be used with a new status. This method will return afte
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 

--- a/content/en/methods/mutes.md
+++ b/content/en/methods/mutes.md
@@ -36,7 +36,7 @@ Accounts the user has muted.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 

--- a/content/en/methods/notifications.md
+++ b/content/en/methods/notifications.md
@@ -343,7 +343,7 @@ Invalid or missing Authorization header.
 
 ---
 
-## (REMOVED) Dismiss a single notification {#dismiss-deprecated}
+## Dismiss a single notification {{%removed%}} {#dismiss-deprecated}
 
 ```http
 POST /api/v1/notifications/dismiss HTTP/1.1

--- a/content/en/methods/notifications.md
+++ b/content/en/methods/notifications.md
@@ -54,7 +54,7 @@ Types to filter include:
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -85,7 +85,7 @@ Sample call with limit=2.
 
 ```http
 GET https://mastodon.social/api/v1/notifications?limit=2 HTTP/1.1
-Authorization: Bearer xxx
+Authorization: Bearer <user_token>
 ```
 
 ##### 200: OK
@@ -196,7 +196,7 @@ View information about a notification with a given ID.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 
@@ -272,7 +272,7 @@ Clear all notifications from the server.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 
@@ -319,7 +319,7 @@ Dismiss a single notification from the server.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 
@@ -363,7 +363,7 @@ Dismiss a single notification from the server.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 id

--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -43,8 +43,8 @@ client_id
 redirect_uri
 : {{<required>}} String. Set a URI to redirect the user to. If this parameter is set to `urn:ietf:wg:oauth:2.0:oob` then the authorization code will be shown instead. Must match one of the `redirect_uris` declared during app registration.
 
-scope
-: String. List of requested OAuth scopes, separated by spaces (or by pluses, if using query parameters). Must be a subset of `scopes` declared during app registration. If not provided, defaults to `read`.
+scope<
+: String. List of requested [OAuth scopes]({{< relref "api/oauth-scopes" >}}), separated by spaces (or by pluses, if using query parameters). Must be a subset of `scopes` declared during app registration. If not provided, defaults to `read`.
 
 state
 : String. Arbitrary value to passthrough to your server when the user authorizes or rejects the authorization request.

--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -220,7 +220,7 @@ We include the additional non-standard property of `app_registration_endpoint` w
 The properties exposed by this endpoint can help you better integrate with the Mastodon API, such as allowing for negotiation of `scopes` across different versions of Mastodon.
 
 {{< hint style="info" >}}
-**Example:** You want to use the `read:me` scope, but also want to support older Mastodon servers that don't have that scope and would need `read:accounts` instead. You could discover whether a server supports that scope by making a request this endpoint.
+**Example:** You want to use the `profile` scope, but also want to support older Mastodon servers that don't have that scope and would need `read:accounts` instead. You could discover whether a server supports that scope by making a request this endpoint.
 {{< /hint >}}
 
 **Returns:** JSON as per the above description\
@@ -269,6 +269,7 @@ The properties exposed by this endpoint can help you better integrate with the M
     "read:statuses",
     "follow",
     "push",
+    "profile",
     "admin:read",
     "admin:read:accounts",
     "admin:read:reports",

--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -305,8 +305,7 @@ The properties exposed by this endpoint can help you better integrate with the M
     "admin:write:domain_blocks",
     "admin:write:ip_blocks",
     "admin:write:email_domain_blocks",
-    "admin:write:canonical_email_blocks",
-    "crypto"
+    "admin:write:canonical_email_blocks"
   ],
   "response_types_supported": ["code"],
   "response_modes_supported": ["query", "fragment", "form_post"],

--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -240,7 +240,7 @@ We include the additional non-standard property of `app_registration_endpoint` w
 The properties exposed by this endpoint can help you better integrate with the Mastodon API, such as allowing for negotiation of `scopes` across different versions of Mastodon.
 
 {{< hint style="info" >}}
-**Example:** You want to use the `profile` scope, but also want to support older Mastodon servers that don't have that scope and would need `read:accounts` instead. You could discover whether a server supports that scope by making a request this endpoint.
+**Example:** You want to use the `profile` scope, but also want to support older Mastodon servers that don't have that scope and would need `read:accounts` instead. You could discover whether a server supports that scope by making a request to this endpoint.
 {{< /hint >}}
 
 **Returns:** JSON as per the above description\

--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -306,9 +306,9 @@ The properties exposed by this endpoint can help you better integrate with the M
 
 On Mastodon versions before 4.3.0, requesting this endpoint will result in a `404 Not Found` error.
 
-This is a good indication that the server is running Mastodon older than 4.3.0 and cannot use features added in 4.3.0 and later versions. Instead, you will need to "guess" what that server supports, instead of discovering supported OAuth 2 endpoints, grant flows & scopes dynamically.
+Instead, you will need to "guess" what that server supports, instead of discovering supported OAuth 2 endpoints, grant flows & scopes dynamically.
 
-You may want to fallback to the [Instance Metadata endpoint]({{% relref ref="methods/instance#v2" %}}) to try to discover what Mastodon version the server is running by parsing the `version` field, however, this is very brittle and not recommended.
+You may want to fallback to the [Instance Metadata endpoint]({{% relref ref="methods/instance#v2" %}}) to try to discover what Mastodon version the server is running by parsing the `version` field; however, this is very brittle and not recommended.
 
 ---
 

--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -292,7 +292,6 @@ The properties exposed by this endpoint can help you better integrate with the M
   "response_modes_supported": ["query", "fragment", "form_post"],
   "grant_types_supported": [
     "authorization_code",
-    "password",
     "client_credentials"
   ],
   "token_endpoint_auth_methods_supported": [

--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -117,7 +117,7 @@ scope
 
 ##### 200: OK
 
-Store this access_token for later use with auth-required methods. The token should be passed as an HTTP `Authorization` header when making API calls, with the value `Bearer access_token`
+Store this `access_token` for later use with methods that require authentication. The token should be passed as an HTTP `Authorization` header when making API calls, with the value `Bearer <access_token>`
 
 {{< hint style="warning" >}}
 Treat the `access_token` as if it were a password. We recommend you encrypt this value when storing in your cache, to prevent credential exposure.\

--- a/content/en/methods/polls.md
+++ b/content/en/methods/polls.md
@@ -43,7 +43,7 @@ View a poll attached to a status.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -109,7 +109,7 @@ Vote on a poll attached to a status.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 

--- a/content/en/methods/preferences.md
+++ b/content/en/methods/preferences.md
@@ -36,7 +36,7 @@ Preferences defined by the user in their account settings.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/profile.md
+++ b/content/en/methods/profile.md
@@ -20,7 +20,7 @@ DELETE /api/v1/profile/avatar HTTP/1.1
 ```
 
 **Returns:** [CredentialAccount]({{< relref "entities/Account#CredentialAccount">}})\
-**OAuth**: User token + `write:accounts`\
+**OAuth:** User token + `write:accounts`\
 **Version history:**\
 4.2.0 - added
 
@@ -102,7 +102,7 @@ DELETE /api/v1/profile/header HTTP/1.1
 ```
 
 **Returns:** [CredentialAccount]({{< relref "entities/Account#CredentialAccount">}})\
-**OAuth**: User token + `write:accounts`\
+**OAuth:** User token + `write:accounts`\
 **Version history:**\
 4.2.0 - added
 

--- a/content/en/methods/profile.md
+++ b/content/en/methods/profile.md
@@ -31,7 +31,7 @@ Deletes the avatar associated with the user's profile.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Path parameters
 
@@ -113,7 +113,7 @@ Deletes the header image associated with the user's profile.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Path parameters
 

--- a/content/en/methods/proofs.md
+++ b/content/en/methods/proofs.md
@@ -23,7 +23,7 @@ aliases: [
 Identity proofs have been deprecated in 3.5.0 and newer. Previously, the only proof provider was Keybase, but development on Keybase has stalled entirely since it was acquired by Zoom.
 {{< /hint >}}
 
-## (REMOVED) View identity proofs {#get}
+## View identity proofs {{%removed%}} {#get}
 
 ```http
 GET /api/proofs HTTP/1.1

--- a/content/en/methods/push.md
+++ b/content/en/methods/push.md
@@ -45,7 +45,8 @@ Add a Web Push API subscription to receive notifications. Each access token can 
 3.3.0 - added `data[alerts][status]`\
 3.4.0 - added `data[policy]`\
 3.5.0 - added `data[alerts][update]` and `data[alerts][admin.sign_up]`\
-4.0.0 - added `data[alerts][admin.report]`
+4.0.0 - added `data[alerts][admin.report]`\
+4.3.0 - added stricter request parameter validation, invalid endpoint URLs and subscription keys will now result in an error, previously these would be accepted, but silently fail.
 
 #### Request
 

--- a/content/en/methods/push.md
+++ b/content/en/methods/push.md
@@ -53,7 +53,7 @@ Add a Web Push API subscription to receive notifications. Each access token can 
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -148,7 +148,7 @@ View the PushSubscription currently associated with this access token.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -212,7 +212,7 @@ Updates the current push subscription. Only the data part can be updated. To cha
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -309,7 +309,7 @@ Removes the current Web Push API subscription.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 

--- a/content/en/methods/reports.md
+++ b/content/en/methods/reports.md
@@ -37,7 +37,7 @@ POST /api/v1/reports HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 

--- a/content/en/methods/scheduled_statuses.md
+++ b/content/en/methods/scheduled_statuses.md
@@ -35,7 +35,7 @@ GET /api/v1/scheduled_statuses HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -109,7 +109,7 @@ GET /api/v1/scheduled_statuses/:id HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -177,7 +177,7 @@ PUT /api/v1/scheduled_statuses/:id HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -258,7 +258,7 @@ DELETE /api/v1/scheduled_statuses/:id HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/search.md
+++ b/content/en/methods/search.md
@@ -37,7 +37,7 @@ GET /api/v2/search HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -172,7 +172,7 @@ GET /api/v1/search HTTP/1.1
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 

--- a/content/en/methods/search.md
+++ b/content/en/methods/search.md
@@ -152,7 +152,7 @@ Invalid or missing Authorization header.
 
 ---
 
-## (REMOVED) Search results (v1) {#v1}
+## Perform a search (v1) {{%removed%}} {#v1}
 
 ```http
 GET /api/v1/search HTTP/1.1

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -38,7 +38,7 @@ Publish a status with the given parameters.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 Idempotency-Key
 : Provide this header with any arbitrary string to prevent duplicate submissions of the same status. Consider using a hash or UUID generated client-side. Idempotency keys are stored for up to 1 hour.
@@ -167,7 +167,7 @@ Obtain information about a status.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -280,7 +280,7 @@ id[]
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -389,7 +389,7 @@ Delete one of your own statuses.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -579,7 +579,7 @@ View statuses above and below this status in the thread.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -661,7 +661,7 @@ lang
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -754,7 +754,7 @@ View who boosted a given status.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -825,7 +825,7 @@ View who favourited a given status.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -896,7 +896,7 @@ Add a status to your favourites list.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -962,7 +962,7 @@ Remove a status from your favourites list.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1029,7 +1029,7 @@ Reshare a status on your own profile.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -1111,7 +1111,7 @@ Undo a reshare of a status.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1177,7 +1177,7 @@ Privately bookmark a status.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1233,7 +1233,7 @@ Remove a status from your private bookmarks.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1299,7 +1299,7 @@ Do not receive notifications for the thread that this status is part of. Must be
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1365,7 +1365,7 @@ Start receiving notifications again for the thread that this status is part of.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1432,7 +1432,7 @@ Feature one of your own public statuses at the top of your profile.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1525,7 +1525,7 @@ Unfeature a status from the top of your profile.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1601,7 +1601,7 @@ Edit a given status to change its text, sensitivity, media attachments, or poll.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Form data parameters
 
@@ -1737,7 +1737,7 @@ Get all known versions of a status, including the initial and current states.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1883,7 +1883,7 @@ Obtain the source properties for a status so that it can be edited.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -1941,7 +1941,7 @@ GET /api/v1/statuses/:id/card HTTP/1.1
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -1918,7 +1918,7 @@ Status does not exist or is private.
 
 ---
 
-## (DEPRECATED) Fetch preview card {#card}
+## Fetch preview card {{%deprecated%}} {#card}
 
 ```http
 GET /api/v1/statuses/:id/card HTTP/1.1

--- a/content/en/methods/streaming.md
+++ b/content/en/methods/streaming.md
@@ -160,7 +160,7 @@ Returns events that are relevant to the authorized user, i.e. home timeline and 
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Events
 
@@ -232,7 +232,7 @@ Returns events for received notifications
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Events
 
@@ -265,7 +265,7 @@ Returns all public statuses
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -317,7 +317,7 @@ Returns all local public statuses
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -368,7 +368,7 @@ Returns all public statuses from remote servers.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -419,7 +419,7 @@ Returns all public statuses for a particular hashtag
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -470,7 +470,7 @@ Returns all local public statuses for a particular hashtag
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -521,7 +521,7 @@ Returns statuses for a list
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -571,7 +571,7 @@ Returns events for received direct messages.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Events
 

--- a/content/en/methods/streaming.md
+++ b/content/en/methods/streaming.md
@@ -254,11 +254,12 @@ GET /api/v1/streaming/public HTTP/1.1
 Returns all public statuses
 
 **Returns:** `update`, `delete`, `status.update`\
-**OAuth:** Public, or app token + `read:statuses`\
+**OAuth:** User token + `read:statuses`\
 **Version history:**\
 1.0.0 - added\
 2.4.0 - add `only_media` parameter\
 3.5.0 - now returns `status.update`
+4.2.0 - changed to require a User token, removing Public and App token access [#23989](https://github.com/mastodon/mastodon/pull/23989)
 
 #### Request
 ##### Headers
@@ -305,11 +306,12 @@ GET /api/v1/streaming/public/local HTTP/1.1
 Returns all local public statuses
 
 **Returns:** `update`, `delete`, `status.update`\
-**OAuth:** Public, or app token + `read:statuses`\
+**OAuth:** User token + `read:statuses`\
 **Version history:**\
 1.1.0 - added\
 2.4.0 - add `only_media` parameter\
 3.5.0 - now returns `status.update`
+4.2.0 - changed to require a User token, removing Public and App token access [#23989](https://github.com/mastodon/mastodon/pull/23989)
 
 #### Request
 ##### Headers
@@ -356,10 +358,11 @@ GET /api/v1/streaming/public/remote HTTP/1.1
 Returns all public statuses from remote servers.
 
 **Returns:** `update`, `delete`, `status.update`\
-**OAuth:** Public, or app token + `read:statuses`\
+**OAuth:** User token + `read:statuses`\
 **Version history:**\
 3.1.4 - added\
 3.5.0 - now returns `status.update`
+4.2.0 - changed to require a User token, removing Public and App token access [#23989](https://github.com/mastodon/mastodon/pull/23989)
 
 #### Request
 ##### Headers
@@ -406,10 +409,11 @@ GET /api/v1/streaming/hashtag HTTP/1.1
 Returns all public statuses for a particular hashtag
 
 **Returns:** `update`, `delete`, `status.update`\
-**OAuth:** Public, or app token + `read:statuses`\
+**OAuth:** User token + `read:statuses`\
 **Version history:**\
 1.0.0 - added\
 3.5.0 - now returns `status.update`
+4.2.0 - changed to require a User token, removing Public and App token access [#23989](https://github.com/mastodon/mastodon/pull/23989)
 
 #### Request
 ##### Headers
@@ -456,10 +460,11 @@ GET /api/v1/streaming/hashtag/local HTTP/1.1
 Returns all local public statuses for a particular hashtag
 
 **Returns:** `update`, `delete`, `status.update`\
-**OAuth:** Public, or app token + `read:statuses`\
+**OAuth:** User token + `read:statuses`\
 **Version history:**\
 1.1.0 - added\
 3.5.0 - now returns `status.update`
+4.2.0 - changed to require a User token, removing Public and App token access [#23989](https://github.com/mastodon/mastodon/pull/23989)
 
 #### Request
 ##### Headers
@@ -510,6 +515,7 @@ Returns statuses for a list
 **Version history:**\
 2.1.0 - added\
 3.5.0 - now returns `status.update`
+4.2.0 - changed to require a User token, removing Public and App token access [#23989](https://github.com/mastodon/mastodon/pull/23989)
 
 #### Request
 ##### Headers
@@ -587,9 +593,10 @@ wss://mastodon.example/api/v1/streaming
 ```
 
 **Returns:** Stream of [Event](#events)\
-**OAuth:** Public, or user token + `read` (or `read:statuses` and/or `read:notifications`)\
+**OAuth:** User token + `read` (or `read:statuses` and/or `read:notifications`)\
 **Version history:**\
 3.3.0 - added
+4.2.0 - changed to require a User token, removing Public and App token access [#23989](https://github.com/mastodon/mastodon/pull/23989)
 
 Open a multiplexed WebSocket connection to receive events.
 
@@ -644,7 +651,7 @@ An example update to the public timeline:
 ```
 
 {{< hint style="warning" >}}
-Note that while the event is JSON-encoded, the `payload` is string-encoded and escaped, so it must be parsed and loaded as JSON from that string.
+Note that while the event is JSON-encoded, the `payload` is string-encoded and escaped, so it must be parsed and loaded as JSON from that string. However, for `delete` and `announcements.delete` events the payload is a string representing an identifier, not a JSON value.
 {{</hint>}}
 
 An example delete event from the public timeline:
@@ -671,7 +678,7 @@ An example filter change by the user:
 ```
 
 {{< hint style="warning" >}}
-Note that the `payload` property is not present for `filters_changed` events.
+Note that the `payload` property is not present for `filters_changed` events. And for `delete` and `announcements.delete` the payload is a string, not an object.
 {{</hint>}}
 
 ## See also

--- a/content/en/methods/suggestions.md
+++ b/content/en/methods/suggestions.md
@@ -37,7 +37,7 @@ Accounts that are promoted by staff, or that the user has had past positive inte
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -104,7 +104,7 @@ Remove an account from follow suggestions.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -145,7 +145,7 @@ Accounts the user has had past positive interactions with, but is not yet follow
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 

--- a/content/en/methods/suggestions.md
+++ b/content/en/methods/suggestions.md
@@ -127,7 +127,7 @@ Invalid or missing Authorization header.
 
 ---
 
-## (DEPRECATED) View follow suggestions (v1) {#v1}
+## View follow suggestions (v1) {{%deprecated%}} {#v1}
 
 ```http
 GET /api/v1/suggestions HTTP/1.1

--- a/content/en/methods/tags.md
+++ b/content/en/methods/tags.md
@@ -40,7 +40,7 @@ Show a hashtag and its associated information
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -116,7 +116,7 @@ Follow a hashtag. Posts containing a followed hashtag will be inserted into your
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK
@@ -213,7 +213,7 @@ Unfollow a hashtag. Posts containing this hashtag will no longer be inserted int
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/timelines.md
+++ b/content/en/methods/timelines.md
@@ -40,7 +40,7 @@ View public statuses.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -119,7 +119,7 @@ View public statuses containing the given hashtag.
 ##### Headers
 
 Authorization
-: Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -248,7 +248,7 @@ View statuses from followed users and hashtags.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -376,7 +376,7 @@ View statuses in the given list timeline.
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 
@@ -449,7 +449,7 @@ x.x.x - added\
 ##### Headers
 
 Authorization
-: {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 ##### Query parameters
 

--- a/content/en/methods/timelines.md
+++ b/content/en/methods/timelines.md
@@ -430,7 +430,7 @@ List is not owned by you or does not exist
 
 ---
 
-## (DEPRECATED) View direct timeline {#direct}
+## View direct timeline {{%deprecated%}} {#direct}
 
 ```http
 GET /api/v1/timelines/direct HTTP/1.1

--- a/content/en/spec/activitypub.md
+++ b/content/en/spec/activitypub.md
@@ -599,7 +599,7 @@ As noted above while listing the [schema.org @context extensions](#schema), Mast
 }
 ```
 
-### Identity proofs {#IdentityProof}
+### Identity proofs {{%deprecated%}} {#IdentityProof}
 
 {{< hint style="warning" >}}
 This property is currently unused/deprecated due to the removal of Keybase support in Mastodon 3.5: <https://github.com/mastodon/mastodon/pull/17045>

--- a/content/en/spec/oauth.md
+++ b/content/en/spec/oauth.md
@@ -13,30 +13,40 @@ The Mastodon API has many methods that require authentication from a client or a
 
 To obtain an OAuth token for a Mastodon website, make sure that you allow your users to specify the domain they want to connect to before login. Use that domain to [acquire a client id/secret]({{< relref "methods/apps#create" >}}) and then [proceed with normal OAuth 2]({{< relref "methods/oauth" >}}).
 
+## OAuth 2 client types {#client-types}
+
+OAuth 2 defines two client types: `confidential` and `public`, based on their ability to authenticate securely with the authorization server (i.e., ability to maintain the confidentiality of their client credentials). Confidential clients are allowed to use the [client credentials grant flow]({{<relref "client/token#flow" >}}), where as public clients cannot.
+
+At present Mastodon only supports confidential clients, however [work is underway](https://github.com/mastodon/mastodon/pull/30329) to add support for public clients.
+
 ## OAuth 2 endpoints implemented {#implementation}
 
 The following descriptions are taken from the [Doorkeeper documentation](https://github.com/doorkeeper-gem/doorkeeper/wiki/API-endpoint-descriptions-and-examples). Mastodon uses Doorkeeper to implement OAuth 2. For more information on how to use these endpoints, see the [API documentation for OAuth.]({{< relref "methods/oauth" >}})
 
 {{< caption-link url="https://github.com/mastodon/mastodon/blob/main/config/initializers/doorkeeper.rb" caption="Doorkeeper config initializer" >}}
 
-### Authorization Server Metadata endpoint (RFC 8414) {#authorization-server-metadata}
+### Authorization Server Metadata endpoint ([RFC 8414](https://www.rfc-editor.org/rfc/rfc8414.html)) {#authorization-server-metadata}
 
-[GET /.well-known/oauth-authorization-server]({{% relref "methods/oauth#authorization-server-metadata" %}})
+Returns a JSON document representing the configuration of the OAuth 2 server in Mastodon. Information includes `scopes` available for use when [registering Applications]({{% relref "methods/apps#create" %}}) or requesting [access tokens]({{% relref "methods/oauth#token" %}}), `grant_types_supported` which are can be used when requesting access tokens, and various endpoints for interacting with the Mastodon OAuth server, such as `authorization_endpoint` and `token_endpoint`.
 
 **Version history:**\
 4.3.0 - added
 
-Returns a JSON document representing the configuration of the OAuth 2 server in Mastodon. Information includes `scopes` available for use when [registering Applications]({{% relref "methods/apps#create" %}}) or requesting [access tokens]({{% relref "methods/oauth#token" %}}), `grant_types_supported` which are can be used when requesting access tokens, and various endpoints for interacting with the Mastodon OAuth server, such as `authorization_endpoint` and `token_endpoint`.
+{{< page-relref ref="methods/oauth#authorization-server-metadata" caption="GET /.well-known/oauth-authorization-server" >}}
 
-### Authorization endpoint (RFC 6749 Section 3.1) {#authorization}
+### Dynamic Client Registration endpoint ([RFC 7591](https://www.rfc-editor.org/rfc/rfc7591.html)) {#dynamic-client-registration}
 
-[GET /oauth/authorize]({{% relref "methods/oauth#authorize" %}})
+At present, Mastodon does not support the Dynamic Client Registration protocol, however it does support a proprietary endpoint for registering an OAuth Application.
+
+{{< page-relref ref="methods/apps#create" caption="POST /api/v1/apps" >}}
+
+### Authorization endpoint ([RFC 6749 Section 3.1](https://www.rfc-editor.org/rfc/rfc6749.html#section-3.1)) {#authorization}
 
 Displays an authorization form to the user. If approved, it will create and return an authorization code, then redirect to the desired `redirect_uri`, or show the authorization code if `urn:ietf:wg:oauth:2.0:oob` was requested.
 
-### Token endpoint (RFC 6749 Section 3.2) {#token}
+{{< page-relref ref="methods/oauth#authorize" caption="GET /oauth/authorize" >}}
 
-[POST /oauth/token]({{% relref "methods/oauth#token" %}})
+### Token endpoint ([RFC 6749 Section 3.2](https://www.rfc-editor.org/rfc/rfc6749.html#section-3.2)) {#token}
 
 Obtain an access token. Mastodon supports the following OAuth 2 flows:
 
@@ -49,11 +59,13 @@ Client credentials flow
 Password grant flow
 : For bots and other single-user applications. Usage [not recommended](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#name-resource-owner-password-cre) by the OAuth 2 Specification authors due to security concerns. This grant flow may be removed in future versions of Mastodon.
 
-### Token revocation endpoint (RFC 7009 Section 2) {#revoke}
+{{< page-relref ref="methods/oauth#token" caption="POST /oauth/token" >}}
 
-[POST /oauth/revoke]({{% relref "methods/oauth#revoke" %}})
+### Token revocation endpoint ([RFC 7009 Section 2](https://www.rfc-editor.org/rfc/rfc7009.html#section-2)) {#revoke}
 
 Post here with client credentials to revoke an access token.
+
+{{< page-relref ref="methods/oauth#revoke" caption="POST /oauth/revoke" >}}
 
 ## Common gotchas {#gotchas}
 

--- a/content/en/spec/oauth.md
+++ b/content/en/spec/oauth.md
@@ -66,6 +66,22 @@ Post here with client credentials to revoke an access token.
 
 {{< page-relref ref="methods/oauth#revoke" caption="POST /oauth/revoke" >}}
 
+## OAuth 2 Security Considerations
+
+### Proof Key for Code Exchange (PKCE) {#pkce}
+
+When performing an OAuth 2 [authorization code flow]({{< relref ref="methods/oauth#authorize" >}}), there is an additional security mechanism that you can employ to increase the security of the authorization code when the user is redirected back to your application. This is known as Proof Key for Code Exchange, or PKCE (pronounced pixie), and is supported by Mastodon 4.3.0 and above.
+
+We recommend, inline with [OAuth 2 Security Best Current Practices](https://www.ietf.org/archive/id/draft-ietf-oauth-security-topics-27.html#name-pkce), to use PKCE with the Authorization Code flow for both confidential clients and public clients.
+
+{{< caption-link url="https://oauth.net/2/pkce/" caption="Learn more about PKCE on the OAuth.net website" >}}
+
+### State Parameter {#state-parameter}
+
+When performing an OAuth 2 [authorization code flow]({{< relref ref="methods/oauth#authorize" >}}), you can  use the [`state` parameter](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1) of the Authorization endpoint to prevent mix-up and cross site request forgery attacks. This parameter is returned back to your server unchanged via the redirect URI upon completion of the OAuth Authorization Code flow.
+
+It is also possible to use this parameter to passthrough arbitrary information to your server via the Authorization Code flow. If you use the `state` parameter, it is recommended that you compare or validate the state value before finishing the authorization code flow (i.e., exchanging the authorization code for an access token).
+
 ## Common gotchas {#gotchas}
 
 - When registering an application using Mastodon's REST API, there is a `scopes` parameter. When interfacing with OAuth endpoints, you must use the `scope` parameter instead, and this parameter's value must be a subset of the `scopes` registered with the app. You cannot include anything that wasn't in the original set.

--- a/content/en/spec/oauth.md
+++ b/content/en/spec/oauth.md
@@ -56,8 +56,7 @@ Authorization code flow
 Client credentials flow
 : For applications that do not act on behalf of users
 
-Password grant flow
-: For bots and other single-user applications. Usage [not recommended](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#name-resource-owner-password-cre) by the OAuth 2 Specification authors due to security concerns. This grant flow may be removed in future versions of Mastodon.
+Mastodon has historically supported the Password Grant flow, however, usage is [not recommended](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#name-resource-owner-password-cre) by the OAuth 2 Specification authors due to security issues, and has subsequently been removed from future versions of Mastodon. Instead, it is recommended that you create an OAuth Application for that user, and use the generated Access Token for interacting with the API.
 
 {{< page-relref ref="methods/oauth#token" caption="POST /oauth/token" >}}
 

--- a/content/en/spec/oauth.md
+++ b/content/en/spec/oauth.md
@@ -19,6 +19,15 @@ The following descriptions are taken from the [Doorkeeper documentation](https:/
 
 {{< caption-link url="https://github.com/mastodon/mastodon/blob/main/config/initializers/doorkeeper.rb" caption="Doorkeeper config initializer" >}}
 
+### Authorization Server Metadata endpoint (RFC 8414) {#authorization-server-metadata}
+
+[GET /.well-known/oauth-authorization-server]({{% relref "methods/oauth#authorization-server-metadata" %}})
+
+**Version history:**\
+4.3.0 - added
+
+Returns a JSON document representing the configuration of the OAuth 2 server in Mastodon. Information includes `scopes` available for use when [registering Applications]({{% relref "methods/apps#create" %}}) or requesting [access tokens]({{% relref "methods/oauth#token" %}}), `grant_types_supported` which are can be used when requesting access tokens, and various endpoints for interacting with the Mastodon OAuth server, such as `authorization_endpoint` and `token_endpoint`.
+
 ### Authorization endpoint (RFC 6749 Section 3.1) {#authorization}
 
 [GET /oauth/authorize]({{% relref "methods/oauth#authorize" %}})
@@ -34,11 +43,11 @@ Obtain an access token. Mastodon supports the following OAuth 2 flows:
 Authorization code flow
 : For end-users
 
-Password grant flow
-: For bots and other single-user applications
-
 Client credentials flow
 : For applications that do not act on behalf of users
+
+Password grant flow
+: For bots and other single-user applications. Usage [not recommended](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#name-resource-owner-password-cre) by the OAuth 2 Specification authors due to security concerns. This grant flow may be removed in future versions of Mastodon.
 
 ### Token revocation endpoint (RFC 7009 Section 2) {#revoke}
 
@@ -48,6 +57,5 @@ Post here with client credentials to revoke an access token.
 
 ## Common gotchas {#gotchas}
 
-* When registering an application using Mastodon's REST API, there is a `scopes` parameter. When interfacing with OAuth endpoints, you must use the `scope` parameter instead, and this parameter's value must be a subset of the `scopes` registered with the app. You cannot include anything that wasn't in the original set.
-* When registering an application using Mastodon's REST API, there is a `redirect_uris` parameter. When interfacing with OAuth endpoints, you must use the `redirect_uri` parameter instead, and this parameter's value must be one of the `redirect_uris` registered with the app.
-
+- When registering an application using Mastodon's REST API, there is a `scopes` parameter. When interfacing with OAuth endpoints, you must use the `scope` parameter instead, and this parameter's value must be a subset of the `scopes` registered with the app. You cannot include anything that wasn't in the original set.
+- When registering an application using Mastodon's REST API, there is a `redirect_uris` parameter. When interfacing with OAuth endpoints, you must use the `redirect_uri` parameter instead, and this parameter's value must be one of the `redirect_uris` registered with the app.

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -46,6 +46,12 @@ other = "required"
 [optional]
 other = "optional"
 
+[deprecated]
+other = "deprecated"
+
+[removed]
+other = "removed"
+
 [nullable]
 other = "nullable"
 

--- a/layouts/shortcodes/deprecated.html
+++ b/layouts/shortcodes/deprecated.html
@@ -1,0 +1,1 @@
+<span class="api-method-parameter-deprecated">{{ i18n "deprecated" }}</span>

--- a/layouts/shortcodes/removed.html
+++ b/layouts/shortcodes/removed.html
@@ -1,0 +1,1 @@
+<span class="api-method-parameter-removed">{{ i18n "removed" }}</span>


### PR DESCRIPTION
- [x] Add `/.well-known/oauth-authorization-server` documentation, per https://github.com/mastodon/mastodon/pull/29191
- [x] Document deprecation of `redirect_uri` on `Application` and addition of `redirect_uris`
- [x] Document added support for mutliple redirect URIs for OAuth Applications, per https://github.com/mastodon/mastodon/pull/29192
- [x] Add warning hints around `client_id`, `client_secret`, `access_token` and `code` values that they should be treated as if they are password, and stored securely.
- [x] Document removal of required `read` scope for `GET /api/v1/apps/verify_credentials` (this now just requires a valid access token), per https://github.com/mastodon/mastodon/pull/27142
- [x] Reworked OAuth Scopes page to be clearer. 
- [x] Document `client_secret_expires_at` on `Application`, per https://github.com/mastodon/mastodon/pull/30317/
- [x] Document the fact that on 4.2.x Applications could be deleted at any time and result in broken authentication flows, fixed by https://github.com/mastodon/mastodon/pull/30316
- [x] Document `Application` vs `CredentialApplication` split, per https://github.com/mastodon/mastodon/pull/29192
- [x] Document new `profile` scope, per https://github.com/mastodon/mastodon/pull/30357 & https://github.com/mastodon/mastodon/pull/29087
- [x] Document PKCE Extension, and why using PKCE is recommended for all applications, per: https://github.com/mastodon/mastodon/pull/31129
- [x] Document Removal of OAuth Resource Owner Password Grant Flow, per: https://github.com/mastodon/mastodon/pull/30960 (removal happens in post-4.3)
- [x] Document Removal of  `crypto` scope, per: https://github.com/mastodon/mastodon/pull/31193

This branch is based on #1444 