### PR TITLE
Add docker documentation

### DIFF
--- a/content/en/admin/docker.md
+++ b/content/en/admin/docker.md
@@ -180,14 +180,7 @@ tootctl accounts create \
   --confirmed \
   --role Owner
 
-tootctl accounts approve admin # admin account username
-```
+tootctl accounts approve alice
 
-### Admin account approval
-
-Login to the container to validate the admin account:
-
-```sh
-docker compose exec -it web bash
-tootctl accounts approve admin # admin account username
+exit
 ```

--- a/content/en/admin/docker.md
+++ b/content/en/admin/docker.md
@@ -13,11 +13,27 @@ menu:
 * A **domain name** (or a subdomain) for the Mastodon server, e.g. `example.com`
 * An email delivery service or other **SMTP server**
 * Latest Docker version installed with compose plugin 
-You will be running the commands as root. If you aren’t already root, switch to root: `sudo -i`
 
 {{< hint style="info" >}}
 It's advised to reed the [security section](https://docs.docker.com/engine/security/) of the docker documentation.
 {{< /hint >}}
+
+You will be running the commands as root. If you aren’t already root, switch to root: `sudo -i`
+
+### Creating the `mastodon` user {#creating-the-mastodon-user}
+
+This is the user account under which Mastodon will live:
+
+```bash
+adduser --disabled-password mastodon
+```
+
+### System packages {#system-packages}
+
+```bash
+apt update
+apt install -y certbot nginx python3-certbot-nginx
+```
 
 ## Setup {#setup}
 

--- a/content/en/admin/docker.md
+++ b/content/en/admin/docker.md
@@ -25,11 +25,11 @@ It's advised to reed the [security section](https://docs.docker.com/engine/secur
 
 ```sh
 # Clone Mastodon git repo
-git clone https://github.com/tootsuite/mastodon.git
+git clone https://github.com/mastodon/mastodon.git
 # Change directory to Mastodon
 cd mastodon
 # Checkout to the latest stable branch
-git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)
+git checkout $(git tag -l | grep '^v[0-9.]*$' | sort -V | tail -n 1)
 ```
 
 In `docker-compose.yml` comment out the lines with `build: . ` for all images (web, streaming, sidekiq).  

--- a/content/en/admin/docker.md
+++ b/content/en/admin/docker.md
@@ -63,27 +63,34 @@ docker compose up db redis -d
 
 By default, the db is configured without a password and with the other default parameters. If you wish to add a password to the db, or use a different user, table etc., you need to modify the `docker-compose.yml` to add the correct variables for the **Postgres** container of the db service.
 
-Then run the configuration script that will create the `.env.production`.
+Then launch the configuration wizard, which will display the `.env.production`.
 
 ```sh
-docker compose run web bundle exec rake mastodon:setup
+docker compose run --rm web bundle exec rake mastodon:setup
 ```
 
 Fill in the required fields.  
 Finally, copy the contents of the generated `.env` and paste it into the `.env.production` on your machine.  
-Confirm the db setup.
+Confirm the PostgreSQL setup.
 
-_If you don't want to configure the db now, you can run the following command later **Please note** this command requires the presence of the `.env.production` with the parameters to connect to the db:_
+{{< hint style="info" >}}
+If for some reason you don't want to configure PostgreSQL now, you can run the following command later.
+**Please note** this command requires the presence of the `.env.production` with the parameters to connect to the db:
 
 ```sh
-docker compose run web bundle exec rails db:setup
+docker compose run --rm web bundle exec rails db:setup
 ```
+{{< /hint >}}
 
 If you have chosen to configure the db with the `mastodon:setup` script, validate the creation of the admin account when requested and copy the generated password.
 
 If the `mastodon:setup` script fails to initialize the db, add the variable `DISABLE_DATABASE_ENVIRONMENT_CHECK=1` in the container shell before re-running the command and validating the destruction of the database.
 
-You can now start the Mastodon instance.
+```sh
+docker compose run -e "DISABLE_DATABASE_ENVIRONMENT_CHECK=1" --rm web bundle exec rake mastodon:setup
+```
+
+You can now start all the Mastodon instance components.
 
 ```sh
 docker compose up -d

--- a/content/en/admin/docker.md
+++ b/content/en/admin/docker.md
@@ -7,7 +7,21 @@ menu:
     parent: admin
 ---
 
-# Mastodon configuration and environment variable generation {#Config and env variable generation}
+## Pre-requisites {#pre-requisites}
+
+* A machine running **Ubuntu 24.04** or **Debian 13** that you have root access to
+* A **domain name** (or a subdomain) for the Mastodon server, e.g. `example.com`
+* An email delivery service or other **SMTP server**
+* Latest Docker version installed with compose plugin 
+You will be running the commands as root. If you aren’t already root, switch to root: `sudo -i`
+
+{{< hint style="info" >}}
+It's advised to reed the [security section](https://docs.docker.com/engine/security/) of the docker documentation.
+{{< /hint >}}
+
+## Setup {#setup}
+
+### Retrieve the last mastodon release {#retrieve-the-last mastodon-release}
 
 ```sh
 # Clone Mastodon git repo

--- a/content/en/admin/docker.md
+++ b/content/en/admin/docker.md
@@ -22,31 +22,31 @@ In `docker-compose.yml` comment out the lines with `build: . ` for all images (w
 Then start the **postgres** db and the **redis**.
 
 ```sh
-docker compose run db redis
+docker compose pull
+docker compose up db redis
 ```
 
-By default the db is configured without a password via the parameter `POSTGRES_HOST_AUTH_METHOD=trust` and with the other parameters by default. It is strongly recommended to add a password to the db and to use another user, a database other than the default one etc... it is necessary to modify the `docker-compose.yml` to add the right variables for the **Postgres** container of the db service. You can refere to [the official documentation](https://hub.docker.com/_/postgres)
+By default, the db is configured without a password and with the other default parameters. If you wish to add a password to the db, or use a different user, table etc., you need to modify the `docker-compose.yml` to add the correct variables for the **Postgres** container of the db service.
 
-Then get the ids of the 2 networks that will be created (`external_network` and `internal_network`). ( `docker network ls` ).  
 Then run the configuration script that will create the `.env.production`.
 
 ```sh
-docker-compose run -it --rm --network <id-net-internal> --network <id-net-external> web bundle exec rake mastodon:setup
+docker compose run web bundle exec rake mastodon:setup
 ```
 
 Fill in the required fields.  
 Finally, copy the contents of the generated `.env` and paste it into the `.env.production` on your machine.  
-Confirm the initial db setup when ask for.
+Confirm the db setup.
 
-_If you don't want to configure the db now, you can run the following command later **Please note** this command requires the presence of the `.env.production` with the parameters to connect to the db:_.
+_If you don't want to configure the db now, you can run the following command later **Please note** this command requires the presence of the `.env.production` with the parameters to connect to the db:_
 
 ```sh
-docker-compose run --rm web bundle exec rails db:setup
+docker compose run web bundle exec rails db:setup
 ```
 
 If you have chosen to configure the db with the `mastodon:setup` script, validate the creation of the admin account when requested and copy the generated password.
 
-If the `mastodon:setup` script fails to initialize the db, it is necessary to add the `DISABLE_DATABASE_ENVIRONMENT_CHECK=1` variable to the container shell before restarting the command and validating the destruction of the database. Or you can remove the Postgres docker container and delete the volumes, and start again the db service with a fresh container.
+If the `mastodon:setup` script fails to initialize the db, add the variable `DISABLE_DATABASE_ENVIRONMENT_CHECK=1` in the container shell before re-running the command and validating the destruction of the database.
 
 You can now start the Mastodon instance.
 
@@ -56,51 +56,56 @@ docker compose up -d
 
 You can't access the Mastodon intance without configuring a reverse proxy like NGINX.
 
-# Reverse-proxy configuration {#Reverse-proxy configuration}
+## Reverse-proxy configuration {#Proxy configuration}
 
-## Creating a self-signed certificate {#Creating a self-signed certificate}
+### Creating a self-signed certificate
 
-Create a self-signed certificate for your Mastodon instance, if you want you can also use `certbot` to generate a certificate if you have your own public domaine.
+Create a self-signed certificate for your Mastodon instance.
 
 ```sh
-sudo mkdir -p /etc/letsencrypt/live/<DNS-NAIME>/
+DOMAIN_DNS='localhost'
 openssl req --nodes -x509 -newkey rsa:4096 -keyout privkey.pem -out fullchain.pem -sha256 -days 365
-sudo chmod root:root privkey.pem
-sudo chmod root:root fullchain.pem
-sudo mv privkey.pem /etc/letsencrypt/live/<DNS-NAIME>/
-sudo mv fullchain.pem /etc/letsencrypt/live/<DNS-NAIME>/
+mkdir -p "certs/live/$DOMAIN_DNS/"
+mv fullchain.pem privkey.pem certs/live/$DOMAIN_DNS/
 ```
 
-Fill in the requested fields, the `Common Name` field must be equal to the value of `LOCAL_DOMAIN` in the `.env.production`.
+Fill in the requested fields, the Common Name field must be equal to the value of `LOCAL_DOMAIN` in the `.env.production`.
 
-## Nginx config {#Nginx config}
+### Nginx config
 
 Based on the [official configuration](https://github.com/mastodon/mastodon/blob/main/dist/nginx.conf), we modify a few elements to make the config work with docker.
 
-- `sed -i "s/try_files \$uri =404;/try_files \$uri @proxy;/" ~/nginx/conf/mastodon.conf`
-- `sed -i "s/server_name example.com;/\server_name <%WEB_DOMAIN%>;/" ~/nginx/conf/mastodon.con`
-- `sed -i 's/server 127.0.0.1:3000/server web:3000/' ~/nginx/conf/mastodon.conf`
-- `sed -i 's/server 127.0.0.1:4000/server streaming:4000/' ~/nginx/conf/mastodon.conf`
-- `sed -i 's/# ssl_certificate\s*\/etc\/letsencrypt\/live\/example.com\/fullchain.pem;/ssl_certificate\t\/etc\/letsencrypt\/live\/<%DNS NAME%>\/fullchain.pem;/' ~/conf/mastodon.conf`
-- `sed -i 's/# ssl_certificate_key\s*\/etc\/letsencrypt\/live\/example.com\/privkey.pem;/ssl_certificate_key\t\/etc\/letsencrypt\/live\/<%DNS NAME%>\/privkey.pem;/' ~/nginx/conf/mastodon.conf`
+```sh
+DOMAIN_DNS='localhost'
+cp dist/nginx.conf dist/nginx_dockerized.conf
+sed -i "s/try_files \$uri =404;/try_files \$uri @proxy;/" dist/nginx_dockerized.conf
+sed -i "s/server_name example.com;/\server_name $DOMAIN_DNS;/" dist/nginx_dockerized.conf
+sed -i 's/server 127.0.0.1:3000/server web:3000/' dist/nginx_dockerized.conf
+sed -i 's/server 127.0.0.1:4000/server streaming:4000/' dist/nginx_dockerized.conf
+sed -i "s/# ssl_certificate\s*\/etc\/letsencrypt\/live\/example.com\/fullchain.pem;/ssl_certificate\t\/etc\/letsencrypt\/live\/$DOMAIN_DNS\/fullchain.pem;/" dist/nginx_dockerized.conf
+sed -i "s/# ssl_certificate_key\s*\/etc\/letsencrypt\/live\/example.com\/privkey.pem;/ssl_certificate_key\t\/etc\/letsencrypt\/live\/$DOMAIN_DNS\/privkey.pem;/" dist/nginx_dockerized.conf
+
+# Patch internal Host header forwarding
+sed -i "s/Host \$host/Host $DOMAIN_DNS/" dist/nginx_dockerized.conf
+```
 
 Then start up the nginx container.
 
 ```sh
-docker run --name nginx -p 80:80 -p 443:443 --network <id-net-internal> --network <id-net-external> -v ~/nginx/conf:/etc/nginx/conf.d:ro -v /etc/letsencrypt:/etc/letsencrypt:ro -d nginx
+docker compose up nginx -d
 ```
 
 Test the instance with a browser. https://<dns-name>`
 
-# Finalization {#Finalization}
+## Finalization {#Finalization}
 
-## 1st Connection with admin account {#1st Connection with admin account}
+### 1st Connection with admin account
 
 If you created the admin account with `mastodon:setup`, log in with the admin account email address and password. Change the default password. All that's left is to approve the admin account.  
 If not, connect to the container, create the admin account and approve it.
 
 ```sh
-docker exec -it <id-web-container> bash
+docker exec -it <id-conteneur-web> bash
 
 RAILS_ENV=production
 
@@ -110,14 +115,14 @@ tootctl accounts create \
   --confirmed \
   --role Owner
 
-tootctl accounts approve admin # pseudo du compte admin
+tootctl accounts approve admin # admin account username
 ```
 
-## Admin account approval {#Admin account approval}
+### Admin account approval
 
 Login to the container to validate the admin account:
 
 ```sh
-docker exec -it <id-web-container> bash
-tootctl accounts approve admin # pseudo du compte admin
+docker exec -it <id-conteneur-web> bash
+tootctl accounts approve admin # admin account username
 ```

--- a/content/en/admin/docker.md
+++ b/content/en/admin/docker.md
@@ -32,12 +32,33 @@ cd mastodon
 git checkout $(git tag -l | grep '^v[0-9.]*$' | sort -V | tail -n 1)
 ```
 
-In `docker-compose.yml` comment out the lines with `build: . ` for all images (web, streaming, sidekiq).  
-Then start the **postgres** db and the **redis**.
+{{< hint style="info" >}}
+If you want to enable ElasticSearch uncomment the `es` service in the `docker-compose.yml`.
+
+If you want to enable federation with Tor instances uncomment the `tor` and the `privoxy` service in `docker-compose.yml`.
+And and the following environment variable to the `.env.production`:
 
 ```sh
+http_hidden_proxy=http://privoxy:8118
+ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
+```
+{{< /hint >}}
+
+### Generation of the `.env.production` file {#generation-of-the-`.env.production`-file}
+
+To generate your `.env.production` file you have several options :
+- Use the interactive setup wizard (recommended)
+- Use the .env.production.sample
+- Consult the [full config option list](https://docs.joinmastodon.org/admin/config/) and add the ones you need.
+
+
+First start the **postgres** db and the **redis**.
+
+```sh
+# Pull all the images so you can work quickly later in the documentation
 docker compose pull
-docker compose up db redis
+# Start the Postgresql and the Redis database in detached mod
+docker compose up db redis -d
 ```
 
 By default, the db is configured without a password and with the other default parameters. If you wish to add a password to the db, or use a different user, table etc., you need to modify the `docker-compose.yml` to add the correct variables for the **Postgres** container of the db service.

--- a/content/en/admin/docker.md
+++ b/content/en/admin/docker.md
@@ -62,7 +62,7 @@ ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
 ```
 {{< /hint >}}
 
-### Generation of the `.env.production` file {#generation-of-the-`.env.production`-file}
+### Generation of the `.env.production` file {#generation-of-the-.env.production-file}
 
 To generate your `.env.production` file you have several options :
 - Use the interactive setup wizard (recommended)
@@ -72,7 +72,8 @@ To generate your `.env.production` file you have several options :
 
 First start the **postgres** db and the **redis**.
 
-```sh
+```bash
+# Be sure to be root and in the /home/mastodon/live/ directory
 # Pull all the images so you can work quickly later in the documentation
 docker compose pull
 # Start the Postgresql and the Redis database in detached mod
@@ -83,38 +84,37 @@ By default, the db is configured without a password and with the other default p
 
 Then launch the configuration wizard, which will display the `.env.production`.
 
-```sh
+```bash
 docker compose run --rm web bundle exec rake mastodon:setup
 ```
 
 Fill in the required fields.  
 Finally, copy the contents of the generated `.env` and paste it into the `.env.production` on your machine.  
+
 Confirm the PostgreSQL setup.
 
 {{< hint style="info" >}}
 If for some reason you don't want to configure PostgreSQL now, you can run the following command later.
 **Please note** this command requires the presence of the `.env.production` with the parameters to connect to the db:
 
-```sh
+```bash
 docker compose run --rm web bundle exec rails db:setup
 ```
 {{< /hint >}}
 
-If you have chosen to configure the db with the `mastodon:setup` script, validate the creation of the admin account when requested and copy the generated password.
+Validate the creation of the admin account when requested and copy the generated password.
 
 If the `mastodon:setup` script fails to initialize the db, add the variable `DISABLE_DATABASE_ENVIRONMENT_CHECK=1` in the container shell before re-running the command and validating the destruction of the database.
 
-```sh
+```bash
 docker compose run -e "DISABLE_DATABASE_ENVIRONMENT_CHECK=1" --rm web bundle exec rake mastodon:setup
 ```
 
 You can now start all the Mastodon instance components.
 
-```sh
+```bash
 docker compose up -d
 ```
-
-You can't access the Mastodon intance without configuring a reverse proxy like NGINX.
 
 ## Reverse-proxy configuration {#Proxy configuration}
 

--- a/content/en/admin/docker.md
+++ b/content/en/admin/docker.md
@@ -39,22 +39,24 @@ apt install -y certbot nginx python3-certbot-nginx
 
 ### Retrieve the last mastodon release {#retrieve-the-last mastodon-release}
 
-```sh
+```bash
+su - mastodon
 # Clone Mastodon git repo
-git clone https://github.com/mastodon/mastodon.git
-# Change directory to Mastodon
-cd mastodon
+git clone https://github.com/mastodon/mastodon.git live
+# Change directory to Mastodon repo
+cd live
 # Checkout to the latest stable branch
-git checkout $(git tag -l | grep '^v[0-9.]*$' | sort -V | tail -n 1)
+git checkout $(git tag -l | grep '^v[0-9.]*$' | sort -V | tail -n 1) && exit
 ```
 
+### Review the `docker-compose.yml` {#review-the-compose-file}
 {{< hint style="info" >}}
 If you want to enable ElasticSearch uncomment the `es` service in the `docker-compose.yml`.
 
 If you want to enable federation with Tor instances uncomment the `tor` and the `privoxy` service in `docker-compose.yml`.
 And and the following environment variable to the `.env.production`:
 
-```sh
+```bash
 http_hidden_proxy=http://privoxy:8118
 ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
 ```

--- a/content/en/admin/docker.md
+++ b/content/en/admin/docker.md
@@ -1,0 +1,123 @@
+---
+title: Run Mastodon inside Docker
+description: Setting Mastodon environnement using docker compose.
+menu:
+  docs:
+    weight: 30
+    parent: admin
+---
+
+# Mastodon configuration and environment variable generation {#Config and env variable generation}
+
+```sh
+# Clone Mastodon git repo
+git clone https://github.com/tootsuite/mastodon.git
+# Change directory to Mastodon
+cd mastodon
+# Checkout to the latest stable branch
+git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)
+```
+
+In `docker-compose.yml` comment out the lines with `build: . ` for all images (web, streaming, sidekiq).  
+Then start the **postgres** db and the **redis**.
+
+```sh
+docker compose run db redis
+```
+
+By default the db is configured without a password via the parameter `POSTGRES_HOST_AUTH_METHOD=trust` and with the other parameters by default. It is strongly recommended to add a password to the db and to use another user, a database other than the default one etc... it is necessary to modify the `docker-compose.yml` to add the right variables for the **Postgres** container of the db service. You can refere to [the official documentation](https://hub.docker.com/_/postgres)
+
+Then get the ids of the 2 networks that will be created (`external_network` and `internal_network`). ( `docker network ls` ).  
+Then run the configuration script that will create the `.env.production`.
+
+```sh
+docker-compose run -it --rm --network <id-net-internal> --network <id-net-external> web bundle exec rake mastodon:setup
+```
+
+Fill in the required fields.  
+Finally, copy the contents of the generated `.env` and paste it into the `.env.production` on your machine.  
+Confirm the initial db setup when ask for.
+
+_If you don't want to configure the db now, you can run the following command later **Please note** this command requires the presence of the `.env.production` with the parameters to connect to the db:_.
+
+```sh
+docker-compose run --rm web bundle exec rails db:setup
+```
+
+If you have chosen to configure the db with the `mastodon:setup` script, validate the creation of the admin account when requested and copy the generated password.
+
+If the `mastodon:setup` script fails to initialize the db, it is necessary to add the `DISABLE_DATABASE_ENVIRONMENT_CHECK=1` variable to the container shell before restarting the command and validating the destruction of the database. Or you can remove the Postgres docker container and delete the volumes, and start again the db service with a fresh container.
+
+You can now start the Mastodon instance.
+
+```sh
+docker compose up -d
+```
+
+You can't access the Mastodon intance without configuring a reverse proxy like NGINX.
+
+# Reverse-proxy configuration {#Reverse-proxy configuration}
+
+## Creating a self-signed certificate {#Creating a self-signed certificate}
+
+Create a self-signed certificate for your Mastodon instance, if you want you can also use `certbot` to generate a certificate if you have your own public domaine.
+
+```sh
+sudo mkdir -p /etc/letsencrypt/live/<DNS-NAIME>/
+openssl req --nodes -x509 -newkey rsa:4096 -keyout privkey.pem -out fullchain.pem -sha256 -days 365
+sudo chmod root:root privkey.pem
+sudo chmod root:root fullchain.pem
+sudo mv privkey.pem /etc/letsencrypt/live/<DNS-NAIME>/
+sudo mv fullchain.pem /etc/letsencrypt/live/<DNS-NAIME>/
+```
+
+Fill in the requested fields, the `Common Name` field must be equal to the value of `LOCAL_DOMAIN` in the `.env.production`.
+
+## Nginx config {#Nginx config}
+
+Based on the [official configuration](https://github.com/mastodon/mastodon/blob/main/dist/nginx.conf), we modify a few elements to make the config work with docker.
+
+- `sed -i "s/try_files \$uri =404;/try_files \$uri @proxy;/" ~/nginx/conf/mastodon.conf`
+- `sed -i "s/server_name example.com;/\server_name <%WEB_DOMAIN%>;/" ~/nginx/conf/mastodon.con`
+- `sed -i 's/server 127.0.0.1:3000/server web:3000/' ~/nginx/conf/mastodon.conf`
+- `sed -i 's/server 127.0.0.1:4000/server streaming:4000/' ~/nginx/conf/mastodon.conf`
+- `sed -i 's/# ssl_certificate\s*\/etc\/letsencrypt\/live\/example.com\/fullchain.pem;/ssl_certificate\t\/etc\/letsencrypt\/live\/<%DNS NAME%>\/fullchain.pem;/' ~/conf/mastodon.conf`
+- `sed -i 's/# ssl_certificate_key\s*\/etc\/letsencrypt\/live\/example.com\/privkey.pem;/ssl_certificate_key\t\/etc\/letsencrypt\/live\/<%DNS NAME%>\/privkey.pem;/' ~/nginx/conf/mastodon.conf`
+
+Then start up the nginx container.
+
+```sh
+docker run --name nginx -p 80:80 -p 443:443 --network <id-net-internal> --network <id-net-external> -v ~/nginx/conf:/etc/nginx/conf.d:ro -v /etc/letsencrypt:/etc/letsencrypt:ro -d nginx
+```
+
+Test the instance with a browser. https://<dns-name>`
+
+# Finalization {#Finalization}
+
+## 1st Connection with admin account {#1st Connection with admin account}
+
+If you created the admin account with `mastodon:setup`, log in with the admin account email address and password. Change the default password. All that's left is to approve the admin account.  
+If not, connect to the container, create the admin account and approve it.
+
+```sh
+docker exec -it <id-web-container> bash
+
+RAILS_ENV=production
+
+tootctl accounts create \
+  alice \
+  --email alice@example.com \
+  --confirmed \
+  --role Owner
+
+tootctl accounts approve admin # pseudo du compte admin
+```
+
+## Admin account approval {#Admin account approval}
+
+Login to the container to validate the admin account:
+
+```sh
+docker exec -it <id-web-container> bash
+tootctl accounts approve admin # pseudo du compte admin
+```

--- a/content/en/admin/docker.md
+++ b/content/en/admin/docker.md
@@ -147,7 +147,7 @@ If you created the admin account with `mastodon:setup`, log in with the admin ac
 If not, connect to the container, create the admin account and approve it.
 
 ```sh
-docker exec -it <id-conteneur-web> bash
+docker compose exec -it web bash
 
 RAILS_ENV=production
 
@@ -165,6 +165,6 @@ tootctl accounts approve admin # admin account username
 Login to the container to validate the admin account:
 
 ```sh
-docker exec -it <id-conteneur-web> bash
+docker compose exec -it web bash
 tootctl accounts approve admin # admin account username
 ```


### PR DESCRIPTION
Hi everyone, 
I've found myself needing to create a local Mastodon instance for a Lab (something that's at test/demo level). 
First of all, I browsed the documentation and the official repository and I saw that the debate on the need / desire to add documentation for docker. 
However, as I haven't found a satisfactory tutorial or alternative on the Internet, I've taken the liberty of making a functional version, as detailed as possible, of what I'd like to find in the official documentation.
I'm sure it's not perfect, but if anyone would like to add or modify it, please don't hesitate.

PS: I didn't know what value to enter for "Weight", please feel free to modify it.

This will (at least partially) resolve these issues :
- resolve #1547 
- resolve #770 
- resolve #793 
