### PR TITLE
Mark MediaAttachment.preview_url, blurhash as nullable

### DIFF
--- a/content/en/entities/MediaAttachment.md
+++ b/content/en/entities/MediaAttachment.md
@@ -186,7 +186,7 @@ aliases: [
 ### `preview_url` {#preview_url}
 
 **Description:** The location of a scaled-down preview of the attachment.\
-**Type:** String (URL)\
+**Type:** {{<nullable>}} String (URL)\
 **Version history:**\
 0.6.0 - added
 

--- a/content/en/entities/MediaAttachment.md
+++ b/content/en/entities/MediaAttachment.md
@@ -219,7 +219,7 @@ More importantly, there may be another topl-level `focus` Hash object on images 
 ### `blurhash` {#blurhash}
 
 **Description:** A hash computed by [the BlurHash algorithm](https://github.com/woltapp/blurhash), for generating colorful preview thumbnails when media has not been downloaded yet.\
-**Type:** String (Blurhash)\
+**Type:** {{<nullable>}} String (Blurhash)\
 **Version history:**\
 2.8.1 - added
 


### PR DESCRIPTION
Had a payload in the wild where `preview_url` was `null` and the method that generates this value can certainly return `nil` if none of its conditions are met: 

https://github.com/mastodon/mastodon/blob/d326ad0ed9a2e874213c9313f25b973638e4b94d/app/serializers/rest/media_attachment_serializer.rb#L30-L38

Also both TootSDK and IceCubesApp have this property as nullable.