### PR TITLE
Remove flag that no longer exists.

### DIFF
--- a/content/en/methods/notifications.md
+++ b/content/en/methods/notifications.md
@@ -540,9 +540,6 @@ min_id
 limit
 : Integer. Maximum number of results to return. Defaults to 40 notification requests. Max 80 notification requests.
 
-dismissed
-: Boolean. Shows only dismissed requests if `true`, and only non-dismissed requests if `false`. Defaults to `false`.
-
 #### Response
 
 ##### 200: OK


### PR DESCRIPTION
See https://github.com/mastodon/mastodon/pull/31008

It feels strange to make such a change withouth amending the version history. But since this has not been officially released yet, I hope it is fine :confused: 