### PR TITLE
Update Ubuntu requirements

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -9,7 +9,7 @@ menu:
 
 ## Pre-requisites {#pre-requisites}
 
-* A machine running **Ubuntu 20.04** or **Debian 11** that you have root access to
+* A machine running **Ubuntu 22.04** or **Debian 11** that you have root access to
 * A **domain name** (or a subdomain) for the Mastodon server, e.g. `example.com`
 * An e-mail delivery service or other **SMTP server**
 

--- a/content/en/admin/prerequisites.md
+++ b/content/en/admin/prerequisites.md
@@ -6,7 +6,7 @@ menu:
     parent: admin
 ---
 
-If you are setting up a fresh machine, it is recommended that you secure it first. Assuming that you are running **Ubuntu 20.04**:
+If you are setting up a fresh machine, it is recommended that you secure it first. Assuming that you are running **Ubuntu 22.04**:
 
 ## Do not allow password-based SSH login (keys only)
 


### PR DESCRIPTION
The current docs indicate that Ubuntu 20.04 is required. 20.04 LTS will reach its EOL in less than a year, and I'd suggest that we shouldn't advise server owners to configure a new 20.04 server.

The current instructions work unchanged with Ubuntu 22.04 LTS, so I've simply updated the requirements.

See also this discussion on reddit: https://www.reddit.com/r/Mastodon/comments/1e8283s/more_current_os_versions/