### PR TITLE
Change {{< type shortcode to {{%

### DIFF
--- a/content/en/entities/DomainBlock.md
+++ b/content/en/entities/DomainBlock.md
@@ -48,7 +48,7 @@ aliases: [
 **Version history:**\
 4.0.0 - added
 
-### `comment` {{<optional>}} {#comment}
+### `comment` {{%optional%}} {#comment}
 
 **Description:** An optional reason for the domain block.\
 **Type:** String\


### PR DESCRIPTION
Fix #1487, work around an error in the rendering of a {{< type shortcode in the autogenerated Table of Content of a page.