### PR TITLE
Fix #1490, Hugo deprecating `.Page.File.Lang`

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,7 +11,7 @@
     {{ .Content }}
 
     <p style="color: #687590;">
-      {{ i18n "lastUpdated" }} {{ .Lastmod.Format "January 2, 2006" }}{{ with .File }} · <a href='https://github.com/mastodon/documentation/tree/main/content/{{ .Lang }}/{{ .Path }}' style="color: #687590;">{{ i18n "improvePage" }}{{ end }}</a>
+      {{ i18n "lastUpdated" }} {{ .Lastmod.Format "January 2, 2006" }}{{ with .File }} · <a href='https://github.com/mastodon/documentation/tree/main/content/{{ page.Language.Lang }}/{{ .Path }}' style="color: #687590;">{{ i18n "improvePage" }}{{ end }}</a>
 
       {{ if .IsTranslated }}
         <br />

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,7 +11,7 @@
     {{ .Content }}
 
     <p style="color: #687590;">
-      {{ i18n "lastUpdated" }} {{ i18n "lastUpdatedDateFormat"  .Lastmod }}{{ with .File }} · <a href='https://github.com/mastodon/documentation/tree/main/content/{{ .Lang }}/{{ .Path }}' style="color: #687590;">{{ i18n "improvePage" }}{{ end }}</a>
+      {{ i18n "lastUpdated" }} {{ i18n "lastUpdatedDateFormat"  .Lastmod }}{{ with .File }} · <a href='https://github.com/mastodon/documentation/tree/main/content/{{ page.Language.Lang }}/{{ .Path }}' style="color: #687590;">{{ i18n "improvePage" }}{{ end }}</a>
 
       {{ if .IsTranslated }}
         <br />

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -35,5 +35,5 @@
     <a href='https://joinmastodon.org'>{{ i18n "joinMastodon" }}</a> · <a href='https://blog.joinmastodon.org'>{{ i18n "blog" }}</a> · <a href='https://mastodon.social/@Mastodon' target='_blank'><i class='fab fa-mastodon'></i></a>
   </p>
 
-  <p class="legal">{{ with .File }}<a href='https://github.com/mastodon/documentation/tree/main/content/{{ .Lang }}/{{ .Path }}'>{{ i18n "viewSource" }}</a> · {{ end }}<a href='https://creativecommons.org/licenses/by-sa/4.0/'>CC BY-SA 4.0</a> · <a href='https://joinmastodon.org/imprint'>{{ i18n "imprint" }}</a></p>
+  <p class="legal">{{ with .File }}<a href='https://github.com/mastodon/documentation/tree/main/content/{{ page.Language.Lang }}/{{ .Path }}'>{{ i18n "viewSource" }}</a> · {{ end }}<a href='https://creativecommons.org/licenses/by-sa/4.0/'>CC BY-SA 4.0</a> · <a href='https://joinmastodon.org/imprint'>{{ i18n "imprint" }}</a></p>
 </footer>


### PR DESCRIPTION
Hugo v0.123.0 deprecated `.Page.File.Lang`, see its release notes: https://github.com/gohugoio/hugo/releases/tag/v0.123.0 . Instead, `.Page.Language.Lang` should be used now.

This PR accordingly patches the relevant places in

* layouts/_default/single.html
* layouts/index.html
* layouts/partials/footer.html
