### PR TITLE
Note on hugo latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img alt="Mastodon" src="https://github.com/mastodon/mastodon/raw/mainlib/assets/wordmark.light.png?raw=true" height="34">
 </picture></h1>
 
-The documentation currently uses Hugo to generate a static site from Markdown. Use `hugo serve` to test the site locally. If build errors occur, ensure [hugo](https://github.com/gohugoio/hugo) is the latest release.
+The documentation currently uses Hugo to generate a static site from Markdown. Use `hugo serve` to test the site locally. If build errors occur, ensure your Hugo version is the same as [docs.joinmastodon.org](https://github.com/mastodon/documentation/blob/main/.github/workflows/deploy.yml#L43).
 
 View the live documentation at [https://docs.joinmastodon.org](https://docs.joinmastodon.org)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img alt="Mastodon" src="https://github.com/mastodon/mastodon/raw/mainlib/assets/wordmark.light.png?raw=true" height="34">
 </picture></h1>
 
-The documentation currently uses Hugo to generate a static site from Markdown. Use `hugo serve` to test the site locally.
+The documentation currently uses Hugo to generate a static site from Markdown. Use `hugo serve` to test the site locally. If build errors occur, ensure [hugo](https://github.com/gohugoio/hugo) is the latest release.
 
 View the live documentation at [https://docs.joinmastodon.org](https://docs.joinmastodon.org)
 


### PR DESCRIPTION
Added note about using latest hugo release. Some distributions and package managers may not be at the latest version, and this could cause a build error. See [hugo intallation](https://gohugo.io/installation/linux/#repository-packages). 