### PR TITLE
Add documentation for `/api/v2/notifications/policy`

### DIFF
--- a/content/en/entities/NotificationPolicy.md
+++ b/content/en/entities/NotificationPolicy.md
@@ -1,0 +1,92 @@
+---
+title: NotificationPolicy
+description: Represents the notification filtering policy of the user.
+menu:
+  docs:
+    parent: entities
+aliases: [
+  "/entities/NotificationPolicy",
+]
+---
+
+## Attributes
+
+### `for_not_following` {#for_not_following}
+
+**Description:** Whether to `accept`, `filter` or `drop` notifications from accounts the user is not following. `drop` will prevent creation of the notification object altogether (without preventing the underlying activity), `filter` will cause it to be marked as filtered, and `accept` will not affect its processing.\
+**Type:** String (one of `accept`, `filter` or `drop`)\
+**Version history:**\
+4.3.0 - added
+
+### `for_not_followers` {#for_not_followers}
+
+**Description:** Whether to `accept`, `filter` or `drop` notifications from accounts that are not following the user. `drop` will prevent creation of the notification object altogether (without preventing the underlying activity), `filter` will cause it to be marked as filtered, and `accept` will not affect its processing.\
+**Type:** String (one of `accept`, `filter` or `drop`)\
+**Version history:**\
+4.3.0 - added
+
+### `for_new_accounts` {#for_new_accounts}
+
+**Description:** Whether to `accept`, `filter` or `drop` notifications from accounts created in the past 30 days. `drop` will prevent creation of the notification object altogether (without preventing the underlying activity), `filter` will cause it to be marked as filtered, and `accept` will not affect its processing.\
+**Type:** String (one of `accept`, `filter` or `drop`)\
+**Version history:**\
+4.3.0 - added
+
+### `for_private_mentions` {#for_private_mentions}
+
+**Description:** Whether to `accept`, `filter` or `drop` notifications from private mentions. `drop` will prevent creation of the notification object altogether (without preventing the underlying activity), `filter` will cause it to be marked as filtered, and `accept` will not affect its processing. Replies to private mentions initiated by the user, as well as accounts the user follows, are always allowed, regardless of this value.\
+**Type:** String (one of `accept`, `filter` or `drop`)\
+**Version history:**\
+4.3.0 - added
+
+### `for_limited_accounts` {#for_limited_accounts}
+
+**Description:** Whether to `accept`, `filter` or `drop` notifications from accounts that were limited by a moderator. `drop` will prevent creation of the notification object altogether (without preventing the underlying activity), `filter` will cause it to be marked as filtered, and `accept` will not affect its processing.
+**Type:** String (one of `accept`, `filter` or `drop`)\
+**Version history:**\
+4.3.0 - added
+
+### `summary` {#summary}
+
+**Description:** Summary of the filtered notifications
+**Type:** Hash\
+**Version history:**\
+4.3.0 - added
+
+### `summary[pending_requests_count]` {#pending_requests_count}
+
+**Description:** Number of different accounts from which the user has non-dismissed filtered notifications. Capped at 100.
+**Type:** Integer\
+**Version history:**\
+4.3.0 - added
+
+### `summary[pending_notifications_count]` {#pending_notifications_count}
+
+**Description:** Number of total non-dismissed filtered notifications. May be inaccurate.
+**Type:** Integer\
+**Version history:**\
+4.3.0 - added
+
+## Example
+
+```json
+
+{
+  "for_not_following": "accept",
+  "for_not_followers": "accept",
+  "for_new_accounts": "accept",
+  "for_private_mentions": "drop",
+  "for_limited_accounts": "filter",
+  "summary": {
+    "pending_requests_count": 0,
+    "pending_notifications_count": 0
+  }
+}
+
+```
+
+## See also
+
+{{< page-relref ref="methods/notifications" caption="notifications API methods" >}}
+
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/notification_policy_serializer.rb" caption="app/serializers/rest/notification_policy_serializer.rb" >}}

--- a/content/en/entities/V1_NotificationPolicy.md
+++ b/content/en/entities/V1_NotificationPolicy.md
@@ -1,11 +1,11 @@
 ---
-title: NotificationPolicy
+title: V1::NotificationPolicy
 description: Represents the notification filtering policy of the user.
 menu:
   docs:
     parent: entities
 aliases: [
-  "/entities/NotificationPolicy",
+  "/entities/v1_NotificationPolicy",
 ]
 ---
 
@@ -81,7 +81,4 @@ aliases: [
 
 {{< page-relref ref="methods/notifications" caption="notifications API methods" >}}
 
-{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/notification_policy_serializer.rb" caption="app/serializers/rest/notification_policy_serializer.rb" >}}
-
-
-
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/v1/notification_policy_serializer.rb" caption="app/serializers/rest/v1/notification_policy_serializer.rb" >}}

--- a/content/en/entities/V1_NotificationPolicy.md
+++ b/content/en/entities/V1_NotificationPolicy.md
@@ -79,6 +79,8 @@ aliases: [
 
 ## See also
 
+{{< page-relref ref="entities/NotificationPolicy" caption="NotificationPolicy (for the released version)" >}}
+
 {{< page-relref ref="methods/notifications" caption="notifications API methods" >}}
 
 {{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/v1/notification_policy_serializer.rb" caption="app/serializers/rest/v1/notification_policy_serializer.rb" >}}

--- a/content/en/entities/V1_NotificationPolicy.md
+++ b/content/en/entities/V1_NotificationPolicy.md
@@ -9,6 +9,10 @@ aliases: [
 ]
 ---
 
+{{< hint style="warning" >}}
+This version of the notification filtering policy API is deprecated and has not shipped in any release. Please refer to the [current version]({{< relref "entities/NotificationPolicy">}}) instead.
+{{</ hint >}}
+
 ## Attributes
 
 ### `filter_not_following` {#filter_not_following}

--- a/content/en/methods/notifications.md
+++ b/content/en/methods/notifications.md
@@ -459,7 +459,7 @@ GET /api/v1/notifications/policy HTTP/1.1
 
 Notifications filtering policy for the user.
 
-**Returns:** [NotificationPolicy]({{< relref "entities/NotificationPolicy" >}})\
+**Returns:** [V1::NotificationPolicy]({{< relref "entities/v1_NotificationPolicy" >}})\
 **OAuth:** User token + `read:notifications`\
 **Version history:**\
 4.3.0 - added
@@ -508,7 +508,7 @@ PATCH /api/v1/notifications/policy HTTP/1.1
 
 Update the user's notifications filtering policy.
 
-**Returns:** [NotificationPolicy]({{< relref "entities/NotificationPolicy" >}})\
+**Returns:** [V1::NotificationPolicy]({{< relref "entities/v1_NotificationPolicy" >}})\
 **OAuth:** User token + `write:notifications`\
 **Version history:**\
 4.3.0 - added

--- a/content/en/methods/notifications.md
+++ b/content/en/methods/notifications.md
@@ -454,12 +454,12 @@ Invalid or missing Authorization header.
 ## Get the filtering policy for notifications {#get-policy}
 
 ```http
-GET /api/v1/notifications/policy HTTP/1.1
+GET /api/v2/notifications/policy HTTP/1.1
 ```
 
 Notifications filtering policy for the user.
 
-**Returns:** [V1::NotificationPolicy]({{< relref "entities/v1_NotificationPolicy" >}})\
+**Returns:** [NotificationPolicy]({{< relref "entities/NotificationPolicy" >}})\
 **OAuth:** User token + `read:notifications`\
 **Version history:**\
 4.3.0 - added
@@ -479,10 +479,11 @@ The response body contains the current notifications filtering policy for the us
 
 ```json
 {
-  "filter_not_following": false,
-  "filter_not_followers": false,
-  "filter_new_accounts": false,
-  "filter_private_mentions": true,
+  "for_not_following": "accept",
+  "for_not_followers": "accept",
+  "for_new_accounts": "accept",
+  "for_private_mentions": "drop",
+  "for_limited_accounts": "filter",
   "summary": {
     "pending_requests_count": 0,
     "pending_notifications_count": 0
@@ -503,12 +504,12 @@ Invalid or missing Authorization header.
 ## Update the filtering policy for notifications
 
 ```http
-PATCH /api/v1/notifications/policy HTTP/1.1
+PATCH /api/v2/notifications/policy HTTP/1.1
 ```
 
 Update the user's notifications filtering policy.
 
-**Returns:** [V1::NotificationPolicy]({{< relref "entities/v1_NotificationPolicy" >}})\
+**Returns:** [NotificationPolicy]({{< relref "entities/NotificationPolicy" >}})\
 **OAuth:** User token + `write:notifications`\
 **Version history:**\
 4.3.0 - added
@@ -522,17 +523,20 @@ Authorization
 
 #### Form data parameters
 
-filter_not_following
-: Boolean. Whether to filter notifications from accounts the user is not following.
+for_not_following
+: String. Whether to `accept`, `filter` or `drop` notifications from accounts the user is not following. `drop` will prevent creation of the notification object altogether (without preventing the underlying activity), `filter` will cause it to be marked as filtered, and `accept` will not affect its processing.
 
-filter_not_followers
-: Boolean. Whether to filter notifications from accounts that are not following the user.
+for_not_followers
+: String. Whether to `accept`, `filter` or `drop` notifications from accounts that are not following the user. `drop` will prevent creation of the notification object altogether (without preventing the underlying activity), `filter` will cause it to be marked as filtered, and `accept` will not affect its processing.
 
-filter_new_accounts
-: Boolean. Whether to filter notifications from accounts created in the past 30 days.
+for_new_accounts
+: String. Whether to `accept`, `filter` or `drop` notifications from accounts created in the past 30 days. `drop` will prevent creation of the notification object altogether (without preventing the underlying activity), `filter` will cause it to be marked as filtered, and `accept` will not affect its processing.
 
-filter_private_mentions
-: Boolean. Whether to filter notifications from private mentions. Replies to private mentions initiated by the user, as well as accounts the user follows, are never filtered.
+for_private_mentions
+: String. Whether to `accept`, `filter` or `drop` notifications from private mentions. `drop` will prevent creation of the notification object altogether (without preventing the underlying activity), `filter` will cause it to be marked as filtered, and `accept` will not affect its processing. Replies to private mentions initiated by the user, as well as accounts the user follows, are always allowed, regardless of this value.
+
+for_limited_accounts
+: String. Whether to `accept`, `filter` or `drop` notifications from accounts that were limited by a moderator. `drop` will prevent creation of the notification object altogether (without preventing the underlying activity), `filter` will cause it to be marked as filtered, and `accept` will not affect its processing.
 
 
 #### Response


### PR DESCRIPTION
This replaces `/api/v1/notifications/policy`, which was deprecated in https://github.com/mastodon/mastodon/pulls/31343

I am not quite sure in which state to leave the V1 documentation, as it's already in use, but was never actually released and might not be in the final version.