### PR TITLE
Add link to Hugo's repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img alt="Mastodon" src="https://github.com/mastodon/mastodon/raw/mainlib/assets/wordmark.light.png?raw=true" height="34">
 </picture></h1>
 
-The documentation currently uses Hugo to generate a static site from Markdown. Use `hugo serve` to test the site locally. If build errors occur, ensure your Hugo version is the same as [docs.joinmastodon.org](https://github.com/mastodon/documentation/blob/main/.github/workflows/deploy.yml#L43).
+The documentation currently uses [Hugo](https://github.com/gohugoio/hugo) to generate a static site from Markdown. Use `hugo serve` to test the site locally. If build errors occur, ensure your Hugo version is the same as [docs.joinmastodon.org](https://github.com/mastodon/documentation/blob/main/.github/workflows/deploy.yml#L43).
 
 View the live documentation at [https://docs.joinmastodon.org](https://docs.joinmastodon.org)
 


### PR DESCRIPTION
Everybody knows what Hugo is, right? Alright, I still had to search for the project's repository before I could start hacking on `mastodon/documentation`.

This PR adds a link to Hugo's repo in the `mastodon/documentation` README to spare everyone the indirection. (It is a rebased version of an earlier PR with the same effect, #1500).
