### PR TITLE
Clarify `scope` parameter of oauth token creation

### DIFF
--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -108,7 +108,7 @@ redirect_uri
 : {{<required>}} String. Set a URI to redirect the user to. If this parameter is set to urn:ietf:wg:oauth:2.0:oob then the token will be shown instead. Must match one of the `redirect_uris` declared during app registration.
 
 scope
-: String. List of requested OAuth scopes, separated by spaces (or by pluses, if using query parameters). If `code` was provided, then this must be equal to the `scope` requested from the user. Otherwise, it must be a subset of `scopes` declared during app registration. If not provided, defaults to `read`.
+: String. List of requested OAuth scopes, separated by spaces (or by pluses, if using query parameters). If `code` was provided, this will be ignored and the response will always include the `scope` requested from the user. Otherwise, it must be a subset of `scopes` declared during app registration. If no `code` _and_ no `scope` is provided, it defaults to `read`.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -108,7 +108,7 @@ redirect_uri
 : {{<required>}} String. Set a URI to redirect the user to. If this parameter is set to urn:ietf:wg:oauth:2.0:oob then the token will be shown instead. Must match one of the `redirect_uris` declared during app registration.
 
 scope
-: String. List of requested OAuth scopes, separated by spaces (or by pluses, if using query parameters). If `code` was provided, this will be ignored and the response will always include the `scope` requested from the user. Otherwise, it must be a subset of `scopes` declared during app registration. If no `code` _and_ no `scope` is provided, it defaults to `read`.
+: String. When `grant_type` is set to `client_credentials`, the list of requested OAuth scopes, separated by spaces (or pluses, if using query parameters). Must be a subset of the scopes requested at the time the application was created. If omitted, it defaults to `read`. Has no effect when `grant_type` is `authorization_code`.
 
 #### Response
 ##### 200: OK


### PR DESCRIPTION
The docs said that if using an authorization code when requesting an oauth token, the `scope` parameter needed to match the one given when obtaining that code. We were made aware that this is not (or no longer) the case. In fact, whatever is passed in `scope` simply gets ignored in this case. The response will always just include the scope(s) originally requested.

This behavior is coming straight from the `doorkeeper` gem. We document this here, because it is a crucial to third-party app authentication, but we do not control when and if this changes between `doorkeeper` releases. So this paragraph here might have been correct at one point.