### PR TITLE
Fix #1523, add missing link to `entities/Status`

### DIFF
--- a/content/en/entities/Status.md
+++ b/content/en/entities/Status.md
@@ -257,7 +257,7 @@ aliases: [
 ### `reblog` {#reblog}
 
 **Description:** The status being reblogged.\
-**Type:** {{<nullable>}} [Status](#) or null\
+**Type:** {{<nullable>}} [Status]({{< relref "entities/status" >}}) or null\
 **Version history:**\
 0.1.0 - added
 


### PR DESCRIPTION
Add a link in the attribute description of `reblog` for the `Status` API entity which was reported missing by @nikclayton.