### PR TITLE
Redis sentinel docs

### DIFF
--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -434,6 +434,42 @@ Defaults to the value of `REDIS_NAMESPACE`.
 
 #### `SIDEKIQ_REDIS_URL`
 
+#### `REDIS_SENTINEL`
+
+Either a single DNS name that resolves one or more A records for [Redis Sentinel](https://redis.io/docs/management/sentinel/), or a comma-delimited list of Redis Sentinel instance IP:PORTs.
+
+#### `REDIS_SENTINEL_MASTER`
+
+The name of the Redis Sentinel master to connect to, defaults to `mymaster`.
+
+#### `REDIS_SENTINEL_PORT`
+
+If using the DNS name approach for `REDIS_SIDEKIQ_SENTINEL`, defines the port to use to connect to the instances resolved. Defaults to `26379`.
+
+#### `CACHE_REDIS_SENTINEL`
+
+Either a single DNS name that resolves one or more A records for [Redis Sentinel](https://redis.io/docs/management/sentinel/), or a comma-delimited list of Redis Sentinel instance IP:PORTs.
+
+#### `CACHE_REDIS_SENTINEL_MASTER`
+
+The name of the Redis Sentinel master to connect to, defaults to `mymaster`.
+
+#### `CACHE_REDIS_SENTINEL_PORT`
+
+If using the DNS name approach for `CACHE_REDIS_SENTINEL`, defines the port to use to connect to the instances resolved. Defaults to `26379`.
+
+#### `SIDEKIQ_REDIS_SENTINEL`
+
+Either a single DNS name that resolves one or more A records for [Redis Sentinel](https://redis.io/docs/management/sentinel/), or a comma-delimited list of Redis Sentinel instance IP:PORTs.
+
+#### `SIDEKIQ_REDIS_SENTINEL_MASTER`
+
+The name of the Redis Sentinel master to connect to, defaults to `mymaster`.
+
+#### `SIDEKIQ_REDIS_SENTINEL_PORT`
+
+If using the DNS name approach for `SIDEKIQ_REDIS_SENTINEL`, defines the port to use to connect to the instances resolved. Defaults to `26379`.
+
 ### Elasticsearch {#elasticsearch}
 
 {{< page-ref page="admin/elasticsearch" >}}

--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -449,7 +449,7 @@ Please note that if you would like to use Redis Sentinel you also need to specif
 
 The name of the Redis Sentinel master to connect to.
 
-Please note that if you would like to use Redis Sentinel you also need to specify `REDIS_SENTINEL_MASTER`.
+Please note that if you would like to use Redis Sentinel you also need to specify `REDIS_SENTINELS`.
 
 **Version history:**\
 4.3.0 - added
@@ -515,7 +515,7 @@ Please note that if you would like to use Redis Sentinel you also need to specif
 
 The name of the Redis Sentinel master to connect to.
 
-Please note that if you would like to use Redis Sentinel you also need to specify `CACHE_REDIS_SENTINEL_MASTER`.
+Please note that if you would like to use Redis Sentinel you also need to specify `CACHE_REDIS_SENTINELS`.
 
 **Version history:**\
 4.3.0 - added
@@ -581,7 +581,7 @@ Please note that if you would like to use Redis Sentinel you also need to specif
 
 The name of the Redis Sentinel master to connect to.
 
-Please note that if you would like to use Redis Sentinel you also need to specify `SIDEKIQ_REDIS_SENTINEL_MASTER`.
+Please note that if you would like to use Redis Sentinel you also need to specify `SIDEKIQ_REDIS_SENTINELS`.
 
 **Version history:**\
 4.3.0 - added

--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -383,8 +383,17 @@ No default.
 
 ### Redis {#redis}
 
+Mastodon uses Redis in three different ways:
+
+* The web application itself uses redis to store data and communicate with the streaming server.
+* Redis is used as cache backend for Rails' built-in caching functionality.
+* Sidekiq, which we use to process background jobs, stores job data in redis.
+
+You can use a single Redis instance for all three use cases. Simple use the appropriate `REDIS_*` variables mentioned below. But you can
+also use two or even three distinct Redis instances by using the variables prefixed with `CACHE_` and `SIDEKIQ_`.
+
 {{< hint style="info" >}}
-It is possible to use a separate Redis server for volatile cache. You may wish to do so if your Redis server starts getting overwhelmed.
+It is advisable to use a separate Redis server for volatile cache. You may wish to do so if your single Redis server starts getting overwhelmed.
 {{</ hint >}}
 
 #### `REDIS_HOST`
@@ -395,9 +404,20 @@ Defaults to `localhost`.
 
 Defaults to `6379`.
 
+#### `REDIS_USER`
+
+Optional. The username used to connect to Redis.
+
+**Version history:**\
+4.3.0 - added
+
+#### `REDIS_PASSWORD`
+
+Optional. The password used to connect to Redis.
+
 #### `REDIS_URL`
 
-If provided, takes precedence over `REDIS_HOST` and `REDIS_PORT`.
+If provided, takes precedence over `REDIS_HOST`, `REDIS_PORT`, `REDIS_USER`, `REDIS_PASSWORD` and sentinel settings.
 
 Example value: `redis://user:password@localhost:6379`
 
@@ -416,6 +436,45 @@ Defaults to `hiredis`, accepted values are `hiredis` or `ruby`.
 
 If provided, namespaces all Redis keys. This allows the sharing of the same Redis database between different projects or Mastodon servers.
 
+#### `REDIS_SENTINELS`
+
+A comma-delimited list of Redis Sentinel instance HOST:PORTs. The port number is optional, if omitted it will use the value given in `REDIS_SENTINEL_PORT` or the default of `26379`.
+
+Please note that if you would like to use Redis Sentinel you also need to specify `REDIS_SENTINEL_MASTER`.
+
+**Version history:**\
+4.3.0 - added
+
+#### `REDIS_SENTINEL_MASTER`
+
+The name of the Redis Sentinel master to connect to.
+
+Please note that if you would like to use Redis Sentinel you also need to specify `REDIS_SENTINEL_MASTER`.
+
+**Version history:**\
+4.3.0 - added
+
+#### `REDIS_SENTINEL_PORT`
+
+The default port for the sentinels given in `REDIS_SENTINELS`.
+
+**Version history:**\
+4.3.0 - added
+
+#### `REDIS_SENTINEL_USER`
+
+The username used to authenticate with sentinels.
+
+**Version history:**\
+4.3.0 - added
+
+#### `REDIS_SENTINEL_PASSWORD`
+
+The password used to authenticate with sentinels.
+
+**Version history:**\
+4.3.0 - added
+
 #### `CACHE_REDIS_HOST`
 
 Defaults to the value of `REDIS_HOST`.
@@ -423,6 +482,17 @@ Defaults to the value of `REDIS_HOST`.
 #### `CACHE_REDIS_PORT`
 
 Defaults to the value of `REDIS_PORT`.
+
+#### `CACHE_REDIS_USER`
+
+Optional. The username used to connect to Redis.
+
+**Version history:**\
+4.3.0 - added
+
+#### `CACHE_REDIS_PASSWORD`
+
+Optional. The password used to connect to Redis.
 
 #### `CACHE_REDIS_URL`
 
@@ -432,43 +502,118 @@ If provided, takes precedence over `CACHE_REDIS_HOST` and `CACHE_REDIS_PORT`. De
 
 Defaults to the value of `REDIS_NAMESPACE`.
 
-#### `SIDEKIQ_REDIS_URL`
+#### `CACHE_REDIS_SENTINELS`
 
-#### `REDIS_SENTINEL`
+A comma-delimited list of Redis Sentinel instance HOST:PORTs. The port number is optional, if omitted it will use a default of `26379`.
 
-Either a single DNS name that resolves one or more A records for [Redis Sentinel](https://redis.io/docs/management/sentinel/), or a comma-delimited list of Redis Sentinel instance IP:PORTs.
+Please note that if you would like to use Redis Sentinel you also need to specify `CACHE_REDIS_SENTINEL_MASTER`.
 
-#### `REDIS_SENTINEL_MASTER`
-
-The name of the Redis Sentinel master to connect to, defaults to `mymaster`.
-
-#### `REDIS_SENTINEL_PORT`
-
-If using the DNS name approach for `REDIS_SIDEKIQ_SENTINEL`, defines the port to use to connect to the instances resolved. Defaults to `26379`.
-
-#### `CACHE_REDIS_SENTINEL`
-
-Either a single DNS name that resolves one or more A records for [Redis Sentinel](https://redis.io/docs/management/sentinel/), or a comma-delimited list of Redis Sentinel instance IP:PORTs.
+**Version history:**\
+4.3.0 - added
 
 #### `CACHE_REDIS_SENTINEL_MASTER`
 
-The name of the Redis Sentinel master to connect to, defaults to `mymaster`.
+The name of the Redis Sentinel master to connect to.
+
+Please note that if you would like to use Redis Sentinel you also need to specify `CACHE_REDIS_SENTINEL_MASTER`.
+
+**Version history:**\
+4.3.0 - added
 
 #### `CACHE_REDIS_SENTINEL_PORT`
 
-If using the DNS name approach for `CACHE_REDIS_SENTINEL`, defines the port to use to connect to the instances resolved. Defaults to `26379`.
+The default port for the sentinels given in `CACHE_REDIS_SENTINELS`.
 
-#### `SIDEKIQ_REDIS_SENTINEL`
+**Version history:**\
+4.3.0 - added
 
-Either a single DNS name that resolves one or more A records for [Redis Sentinel](https://redis.io/docs/management/sentinel/), or a comma-delimited list of Redis Sentinel instance IP:PORTs.
+#### `CACHE_REDIS_SENTINEL_USER`
+
+The username used to authenticate with sentinels.
+
+**Version history:**\
+4.3.0 - added
+
+#### `CACHE_REDIS_SENTINEL_PASSWORD`
+
+The password used to authenticate with sentinels.
+
+**Version history:**\
+4.3.0 - added
+
+#### `SIDEKIQ_REDIS_HOST`
+
+Defaults to the value of `REDIS_HOST`.
+
+#### `SIDEKIQ_REDIS_PORT`
+
+Defaults to the value of `REDIS_PORT`.
+
+#### `SIDEKIQ_REDIS_USER`
+
+Optional. The username used to connect to Redis.
+
+**Version history:**\
+4.3.0 - added
+
+#### `SIDEKIQ_REDIS_PASSWORD`
+
+Optional. The password used to connect to Redis.
+
+#### `SIDEKIQ_REDIS_URL`
+
+If provided, takes precedence over `SIDEKIQ_REDIS_HOST` and `SIDEKIQ_REDIS_PORT`. Defaults to the value of `REDIS_URL`.
+
+#### `SIDEKIQ_REDIS_NAMESPACE`
+
+Defaults to the value of `REDIS_NAMESPACE`.
+
+#### `SIDEKIQ_REDIS_SENTINELS`
+
+A comma-delimited list of Redis Sentinel instance HOST:PORTs. The port number is optional, if omitted it will use a default of `26379`.
+
+Please note that if you would like to use Redis Sentinel you also need to specify `SIDEKIQ_REDIS_SENTINEL_MASTER`.
+
+**Version history:**\
+4.3.0 - added
 
 #### `SIDEKIQ_REDIS_SENTINEL_MASTER`
 
-The name of the Redis Sentinel master to connect to, defaults to `mymaster`.
+The name of the Redis Sentinel master to connect to.
+
+Please note that if you would like to use Redis Sentinel you also need to specify `SIDEKIQ_REDIS_SENTINEL_MASTER`.
+
+**Version history:**\
+4.3.0 - added
 
 #### `SIDEKIQ_REDIS_SENTINEL_PORT`
 
-If using the DNS name approach for `SIDEKIQ_REDIS_SENTINEL`, defines the port to use to connect to the instances resolved. Defaults to `26379`.
+The default port for the sentinels given in `SIDEKIQ_REDIS_SENTINELS`.
+
+**Version history:**\
+4.3.0 - added
+
+#### `SIDEKIQ_REDIS_SENTINEL_USER`
+
+The username used to authenticate with sentinels.
+
+**Version history:**\
+4.3.0 - added
+
+#### `SIDEKIQ_REDIS_SENTINEL_PASSWORD`
+
+The password used to authenticate with sentinels.
+
+**Version history:**\
+4.3.0 - added
+
+### Elasticsearch {#elasticsearch}
+
+{{< page-ref page="admin/elasticsearch" >}}
+
+#### `ES_ENABLED`
+
+If set to `true`, Mastodon will use Elasticsearch for its search functions.
 
 ### Elasticsearch {#elasticsearch}
 

--- a/content/en/admin/scaling.md
+++ b/content/en/admin/scaling.md
@@ -390,7 +390,11 @@ systemctl restart redis-sidekiq.service
 
 ## Redis Sentinel for High Availability {#redis-sentinel}
 
-As mentioned, Redis is a critical part of a Mastodon instance's operation. By default, your deployment will use a single Redis instance, or multiple if you've setup a cache. However if that instance goes down it can bring the entire Mastodon instance down as well. To alleviate this, Redis Sentinel can be used to track your Redis instances and automatically direct clients to a new primary if one goes down. You can specify `REDIS_SENTINEL`, which is either a DNS name that resolves to the IPs of your Redis Sentinel instances (e.g a Kubernetes service) or a comma-delimited list of the IP:Port combinations directly, that Mastodon can talk with to determine the current master Redis node. By default Sentinel will set an instance as down and select a new master after a minute of the current master being unreachable, but this can be configured based on your setup.
+As mentioned, Redis is a critical part of a Mastodon instance's operation. By default, your deployment will use a single Redis instance, or multiple if you've setup a cache. However if that instance goes down it can bring the entire Mastodon instance down as well. To alleviate this, Redis Sentinel can be used to track your Redis instances and automatically direct clients to a new primary if one goes down. You can specify `REDIS_SENTINELS`, which is a comma-delimited list of the IP:Port combinations of sentinels that Mastodon can talk with to determine the current master Redis node. You also need to specify the name of the master you would like to connect to in `REDIS_SENTINEL_MASTER`. By default Sentinel will set an instance as down and select a new master after a minute of the current master being unreachable, but this can be configured based on your setup.
+
+All sentinel-related variables are also available prefixed with `CACHE_` and `SIDEKIQ_` in case you use more than one redis instance.
+
+Learn more about Redis sentinel here: https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/
 
 ## Read-replicas {#read-replicas}
 

--- a/content/en/admin/scaling.md
+++ b/content/en/admin/scaling.md
@@ -387,6 +387,11 @@ systemctl restart mastodon-web.service
 systemctl restart redis-sidekiq.service
 ```
 
+
+## Redis Sentinel for High Availability {#redis-sentinel}
+
+As mentioned, Redis is a critical part of a Mastodon instance's operation. By default, your deployment will use a single Redis instance, or multiple if you've setup a cache. However if that instance goes down it can bring the entire Mastodon instance down as well. To alleviate this, Redis Sentinel can be used to track your Redis instances and automatically direct clients to a new primary if one goes down. You can specify `REDIS_SENTINEL`, which is either a DNS name that resolves to the IPs of your Redis Sentinel instances (e.g a Kubernetes service) or a comma-delimited list of the IP:Port combinations directly, that Mastodon can talk with to determine the current master Redis node. By default Sentinel will set an instance as down and select a new master after a minute of the current master being unreachable, but this can be configured based on your setup.
+
 ## Read-replicas {#read-replicas}
 
 To reduce the load on your PostgreSQL server, you may wish to set up hot streaming replication (read replica). [See this guide for an example](https://cloud.google.com/community/tutorials/setting-up-postgres-hot-standby).


### PR DESCRIPTION
Adds documentation for using Redis Sentinels based on the original in #1311.

Only this time, the changes have already been merged.

I also added some missing environment variables related to redis and some explanations / clarifications.