### PR TITLE
Deprecate redis namespace

### DIFF
--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -436,6 +436,13 @@ Defaults to `hiredis`, accepted values are `hiredis` or `ruby`.
 
 If provided, namespaces all Redis keys. This allows the sharing of the same Redis database between different projects or Mastodon servers.
 
+{{< hint style="warning" >}}
+This option is deprecated. Sidekiq 7+ removes support for namespaces and one day we will have to upgrade. For everyone using this option today, we will not remove this option without a migration / replacement plan. For everyone setting up a new instance, please do not use this option.
+{{</ hint >}}
+
+**Version history:**\
+4.3.0 - deprecated
+
 #### `REDIS_SENTINELS`
 
 A comma-delimited list of Redis Sentinel instance HOST:PORTs. The port number is optional, if omitted it will use the value given in `REDIS_SENTINEL_PORT` or the default of `26379`.

--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -437,7 +437,7 @@ Defaults to `hiredis`, accepted values are `hiredis` or `ruby`.
 If provided, namespaces all Redis keys. This allows the sharing of the same Redis database between different projects or Mastodon servers.
 
 {{< hint style="warning" >}}
-This option is deprecated. Sidekiq 7+ removes support for namespaces and one day we will have to upgrade. For everyone using this option today, we will not remove this option without a migration / replacement plan. For everyone setting up a new instance, please do not use this option.
+This option is deprecated. Sidekiq 7 removes support for namespaces, and so will a future version of Mastodon. We will attempt to document a clear migration path by the time that happens. If you are setting up a new instance, using this option is highly discouraged.
 {{</ hint >}}
 
 **Version history:**\


### PR DESCRIPTION
This is my suggestion to deprecate `REDIS_NAMESPACE` in 4.3.

We will have to remove it at some point and even though our migration plan is not yet fully fleshed out, I believe we should discourage new installations from using it as to not make the problem even bigger.