### PR TITLE
Remove instructions for cleanup crons

### DIFF
--- a/content/en/admin/setup.md
+++ b/content/en/admin/setup.md
@@ -47,20 +47,3 @@ After logging in, navigate to the **Site settings** page (under **Preferences** 
 | Custom extended information | You can put all sorts of information in here but a **code of conduct** is recommended |
 
 After you fill these in, click “Save changes”.
-
-## Running periodic cleanup tasks {#cleanup}
-
-Mastodon generates some temporary files that are worth cleaning up after a certain amount of time (e.g. to save money on hosting). In general, you want to set up `cron` jobs (or another mechanism) to run these periodic cleanup tasks.
-
-Typically you want to run [`tootctl media remove`](https://docs.joinmastodon.org/admin/tootctl/#media) and [`tootctl preview_cards remove`](https://docs.joinmastodon.org/admin/tootctl/#preview_cards) periodically. These will clean up remote media (e.g. images, videos, audio) and preview cards (e.g. preview images for links) after a certain number of days. (Check the docs for those commands if you want to tweak how old something has to be before it's cleaned up.)
-
-First, run `crontab -e` to edit the cronfile for the `mastodon` user. (If you get a prompt asking which editor to use, choose your favorite editor.)
-
-Next, add something like the following to the bottom of the file:
-
-    @weekly RAILS_ENV=production /home/mastodon/live/bin/tootctl media remove
-    @weekly RAILS_ENV=production /home/mastodon/live/bin/tootctl preview_cards remove
-
-This will run these two commands on a weekly basis.
-
-Finally, save the file. You can use `crontab -l` to verify the configuration.


### PR DESCRIPTION
Since the retention policy for cached content and media was added (#19232) a external cron is no longer needed.

Keeping this in the documentation could lead to confusion or redundant setups.