### PR TITLE
Update installation instructions for 4.3 on Ubuntu 24.04 and Debian 12

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -60,41 +60,12 @@ Enable `corepack` so that the correct version of `yarn` can be installed automat
 corepack enable
 ```
 
-### Installing Ruby {#installing-ruby}
+### Creating the `mastodon` user {#creating-the-mastodon-user}
 
-We will use rbenv to manage Ruby versions as it simplifies obtaining the correct versions and updating them when new releases are available. Since rbenv needs to be installed for an individual Linux user, we must first create the user account under which Mastodon will run:
+This is the user account under which Mastodon will run:
 
 ```bash
 adduser --disabled-password mastodon
-```
-
-We can then switch to the user:
-
-```bash
-su - mastodon
-```
-
-And proceed to install rbenv and rbenv-build:
-
-```bash
-git clone https://github.com/rbenv/rbenv.git ~/.rbenv
-echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
-echo 'eval "$(rbenv init -)"' >> ~/.bashrc
-exec bash
-git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
-```
-
-Once this is done, we can install the correct Ruby version:
-
-```bash
-RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install 3.3.5
-rbenv global 3.3.5
-```
-
-Return to the root user:
-
-```bash
-exit
 ```
 
 ## Setup {#setup}
@@ -139,6 +110,25 @@ Use git to download the latest stable release of Mastodon:
 ```bash
 git clone https://github.com/mastodon/mastodon.git live && cd live
 git checkout $(git tag -l | grep '^v[0-9.]*$' | sort -V | tail -n 1)
+```
+
+#### Installing Ruby {#installing-ruby}
+
+We will use rbenv to manage Ruby versions as it simplifies obtaining the correct versions and updating them when new releases are available.
+Install rbenv and ruby-build:
+
+```bash
+git clone https://github.com/rbenv/rbenv.git ~/.rbenv
+echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
+echo 'eval "$(rbenv init -)"' >> ~/.bashrc
+exec bash
+git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
+```
+
+Once this is done, we can install the correct Ruby version:
+
+```bash
+RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install
 ```
 
 #### Installing the last dependencies {#installing-the-last-dependencies}

--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -200,19 +200,11 @@ Then edit `/etc/nginx/sites-available/mastodon` to
 
 3. Make any other adjustments you might need.
 
-Add nginx's `www-data` user to the `mastodon` group to allow nginx to access asset files
+Allow other users to traverse the mastodon user's home directory, so that nginx's `www-data` user can access asset files:
 
 ```bash
-usermod -aG mastodon www-data
+chmod o+x /home/mastodon
 ```
-
-{{< hint style="info" >}}
-On Debian 12 there is one additional step, because by default the `mastodon` group may not access the `/home/mastodon` directory:
-
-```bash
-chmod g+x /home/mastodon
-```
-{{< /hint >}}
 
 Restart nginx for the changes to take effect:
 

--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -9,11 +9,13 @@ menu:
 
 ## Pre-requisites {#pre-requisites}
 
-* A machine running **Ubuntu 22.04** or **Debian 11** that you have root access to
+* A machine running **Ubuntu 24.04** or **Debian 12** that you have root access to
 * A **domain name** (or a subdomain) for the Mastodon server, e.g. `example.com`
 * An e-mail delivery service or other **SMTP server**
 
-You will be running the commands as root. If you aren’t already root, switch to root: `sudo su -`
+We will be using `example.com` as the domain in the following example. Please remember to replace it with your own domain before running any commands.
+
+You will be running the commands as root. If you aren’t already root, switch to root: `sudo -i`
 
 ### System repositories {#system-repositories}
 
@@ -52,9 +54,10 @@ apt install -y \
 
 #### Yarn {#yarn}
 
+Enable `corepack` so that the correct version of `yarn` can be installed automatically:
+
 ```bash
 corepack enable
-yarn set version classic
 ```
 
 ### Installing Ruby {#installing-ruby}
@@ -62,7 +65,7 @@ yarn set version classic
 We will use rbenv to manage Ruby versions as it simplifies obtaining the correct versions and updating them when new releases are available. Since rbenv needs to be installed for an individual Linux user, we must first create the user account under which Mastodon will run:
 
 ```bash
-adduser --disabled-login mastodon
+adduser --disabled-password mastodon
 ```
 
 We can then switch to the user:
@@ -84,14 +87,8 @@ git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-b
 Once this is done, we can install the correct Ruby version:
 
 ```bash
-RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install 3.2.3
-rbenv global 3.2.3
-```
-
-We’ll also need to install the bundler:
-
-```bash
-gem install bundler --no-document
+RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install 3.3.5
+rbenv global 3.3.5
 ```
 
 Return to the root user:
@@ -106,7 +103,7 @@ exit
 
 #### Performance configuration (optional) {#performance-configuration-optional}
 
-For optimal performance, you may use [pgTune](https://pgtune.leopard.in.ua/#/) to generate an appropriate configuration and edit values in `/etc/postgresql/16/main/postgresql.conf` before restarting PostgreSQL with `systemctl restart postgresql`
+For optimal performance, you may use [pgTune](https://pgtune.leopard.in.ua/#/) to generate an appropriate configuration and edit values in `/etc/postgresql/16/main/postgresql.conf` before restarting PostgreSQL with `systemctl restart postgresql`.
 
 #### Creating a user {#creating-a-user}
 
@@ -152,7 +149,7 @@ Now to install Ruby and JavaScript dependencies:
 bundle config deployment 'true'
 bundle config without 'development test'
 bundle install -j$(getconf _NPROCESSORS_ONLN)
-yarn install --pure-lockfile
+yarn install
 ```
 
 {{< hint style="info" >}}
@@ -164,7 +161,7 @@ The two `bundle config` commands are only needed the first time you're installin
 Run the interactive setup wizard:
 
 ```bash
-RAILS_ENV=production bundle exec rake mastodon:setup
+RAILS_ENV=production bin/rails mastodon:setup
 ```
 
 This will:
@@ -204,21 +201,33 @@ rm /etc/nginx/sites-enabled/default
 Then edit `/etc/nginx/sites-available/mastodon` to 
 
 1. Replace `example.com` with your own domain name
-2. Uncomment the `ssl_certificate` and `ssl_certificate_key` lines and replace the two lines with (ignore this step if you are bringing your own certificate)
+2. Uncomment the `ssl_certificate` and `ssl_certificate_key` (ignore this step if you are bringing your own certificate):
 
-```
-ssl_certificate     /etc/ssl/certs/ssl-cert-snakeoil.pem;
-ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
-```
+    ```
+    ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;;
+    ```
 
 3. Make any other adjustments you might need.
 
-Un-comment the lines starting with `ssl_certificate` and `ssl_certificate_key`, updating the path with the correct domain name.
-
-Reload nginx for the changes to take effect:
+Add nginx's `www-data` user to the `mastodon` group to allow nginx to access asset files
 
 ```bash
-systemctl reload nginx
+usermod -aG mastodon www-data
+```
+
+{{< hint style="info" >}}
+On Debian 12 there is one additional step, because by default the `mastodon` group may not access the `/home/mastodon` directory:
+
+```bash
+chmod g+x /home/mastodon
+```
+{{< /hint >}}
+
+Restart nginx for the changes to take effect:
+
+```bash
+systemctl restart nginx
 ```
 
 At this point, you should be able to visit your domain in the browser and see the elephant hitting the computer screen error page. This is because we haven’t started the Mastodon process yet.


### PR DESCRIPTION
This brings the installation instructions up-to-date with the upcoming 4.3 release and the current stable releases of the two operating systems.

I changed some punctuation, version numbers, removed commands that are no longer necessary and simplified a couple of others.

The biggest changes are due to changes in the two operating systems:

* `adduser --disabled-login` no longer sets a shell for the user it creates. I changed it to `--disabled-password` which should have roughly the same effect (preventing remote logins) as the old `--disabled-login`.
* We have a couple of open issues and PRs because nginx needs to access assets and was no longer able to in newer OS versions because default permissions on home directories changed. I added a step to add the `www-data` user to the `mastodon` group, which solves the problem on Ubuntu, and added a hint with the extra `chmod` needed on Debian.

I tested this successfully on a fresh install of both Ubuntu 24.04 and Debian 12.

Resolves #1003, #1055, #1128, #1132, #1198, #1471, #1473 and mastodon/mastodon#27223