### PR TITLE
Fix typo in oauth api parameters

### DIFF
--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -43,7 +43,7 @@ client_id
 redirect_uri
 : {{<required>}} String. Set a URI to redirect the user to. If this parameter is set to `urn:ietf:wg:oauth:2.0:oob` then the authorization code will be shown instead. Must match one of the `redirect_uris` declared during app registration.
 
-scope<
+scope
 : String. List of requested [OAuth scopes]({{< relref "api/oauth-scopes" >}}), separated by spaces (or by pluses, if using query parameters). Must be a subset of `scopes` declared during app registration. If not provided, defaults to `read`.
 
 state


### PR DESCRIPTION
I noticed this when reviewing #1445 but thought this was on purpose (confusing special characters used by different markup languages here :man_facepalming:).