### PR TITLE
Remove non-functional hosting providers

### DIFF
--- a/content/en/user/run-your-own.md
+++ b/content/en/user/run-your-own.md
@@ -44,8 +44,6 @@ There exist a number of **dedicated Mastodon hosting providers** that take care 
 
 {{< caption-link url="https://weingaertner-it.de" caption="Weingärtner IT" >}}
 
-{{< caption-link url="https://fedi.monster/" caption="Fedi.monster" >}}
-
 {{< caption-link url="https://cloudplane.org" caption="Cloudplane" >}}
 
 {{< caption-link url="https://ungleich.ch/u/products/mastodon-hosting/" caption="ungleich.ch" >}}

--- a/content/en/user/run-your-own.md
+++ b/content/en/user/run-your-own.md
@@ -40,8 +40,6 @@ There exist a number of **dedicated Mastodon hosting providers** that take care 
 
 {{< caption-link url="https://hostdon.jp" caption="Hostdon" >}}
 
-{{< caption-link url="https://app.spacebear.ee/mastodon" caption="Spacebear" >}}
-
 {{< caption-link url="https://ossrox.org" caption="Ossrox" >}}
 
 {{< caption-link url="https://weingaertner-it.de" caption="Weingärtner IT" >}}

--- a/content/en/user/run-your-own.md
+++ b/content/en/user/run-your-own.md
@@ -44,8 +44,6 @@ There exist a number of **dedicated Mastodon hosting providers** that take care 
 
 {{< caption-link url="https://weingaertner-it.de" caption="Weingärtner IT" >}}
 
-{{< caption-link url="https://cloudplane.org" caption="Cloudplane" >}}
-
 {{< caption-link url="https://ungleich.ch/u/products/mastodon-hosting/" caption="ungleich.ch" >}}
 
 Managed hosting solutions are great for those who do not have experience or desire to install and maintain software. However, being in charge of all components on your own hardware gives greater control over scaling, performance and customization.


### PR DESCRIPTION
Removes non-functional hosting providers:

- Spacebear link does not function
- FediMonster is no longer accepting new clients
- Cloudplane is shutting down in December