### PR TITLE
Add tool-versions file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+hugo extended_0.130.0


### PR DESCRIPTION
This helps software like asdf discover exactly what version of hugo to use, since hugo versions often have incompatibilities.

I've been bitten many times working on docs but having the wrong version of hugo in my $PATH