### PR TITLE
Add media attachment description limit

### DIFF
--- a/content/en/entities/Instance.md
+++ b/content/en/entities/Instance.md
@@ -392,6 +392,13 @@ aliases: [
 **Version history:**\
 4.0.0 - added
 
+##### `configuration[media_attachments][description_limit]` {#description_limit}
+
+**Description:** The maximum size of a description, in characters.\
+**Type:** Integer\
+**Version history:**\
+4.4.0 - added
+
 ##### `configuration[media_attachments][image_size_limit]` {#image_size_limit}
 
 **Description:** The maximum size of any uploaded image, in bytes.\

--- a/content/en/entities/Instance.md
+++ b/content/en/entities/Instance.md
@@ -101,6 +101,7 @@ aliases: [
         "audio/3gpp",
         "video/x-ms-asf"
       ],
+      "description_limit": 1500,
       "image_size_limit": 10485760,
       "image_matrix_limit": 16777216,
       "video_size_limit": 41943040,

--- a/content/en/methods/instance.md
+++ b/content/en/methods/instance.md
@@ -122,6 +122,7 @@ Obtain general information about the server.
         "audio/3gpp",
         "video/x-ms-asf"
       ],
+      "description_limit": 1500,
       "image_size_limit": 10485760,
       "image_matrix_limit": 16777216,
       "video_size_limit": 41943040,


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/33153

<img width="628" alt="Screenshot 2024-12-04 at 09 39 58" src="https://github.com/user-attachments/assets/95991207-0f51-4f67-b4f7-76cbdb76786c">
