### PR TITLE
Remove accidentally included `application_id` params attribute from `ScheduledStatus`

### DIFF
--- a/content/en/entities/ScheduledStatus.md
+++ b/content/en/entities/ScheduledStatus.md
@@ -32,7 +32,6 @@ Returned from `POST /api/v1/statuses?status=test post&scheduled_at=2022-09-29`
     "idempotency": null,
     "with_rate_limit": false,
     "in_reply_to_id": null,
-    "application_id": 3
   },
   "media_attachments": []
 }
@@ -54,7 +53,6 @@ Returned from `GET /api/v1/scheduled_statuses`:
     "idempotency": null,
     "scheduled_at": null,
     "spoiler_text": null,
-    "application_id": 3,
     "in_reply_to_id": null,
     "with_rate_limit": false
   },
@@ -170,13 +168,6 @@ Returned from `GET /api/v1/scheduled_statuses`:
 
 **Description:** The language that will be used for the status.\
 **Type:** {{<nullable>}} String (ISO 639-1 two-letter language code)\
-**Version history:**\
-2.7.0 - added
-
-#### `params[application_id]` {#params-application_id}
-
-**Description:** ID of the Application that posted the status.\
-**Type:** Integer\
 **Version history:**\
 2.7.0 - added
 

--- a/content/en/methods/scheduled_statuses.md
+++ b/content/en/methods/scheduled_statuses.md
@@ -68,7 +68,6 @@ limit
       "idempotency": null,
       "scheduled_at": null,
       "spoiler_text": null,
-      "application_id": 596551,
       "in_reply_to_id": null
     },
     "media_attachments": []
@@ -127,7 +126,6 @@ Authorization
     "idempotency": null,
     "scheduled_at": null,
     "spoiler_text": null,
-    "application_id": 596551,
     "in_reply_to_id": null
   },
   "media_attachments": []
@@ -200,7 +198,6 @@ scheduled_at
     "idempotency": null,
     "scheduled_at": null,
     "spoiler_text": null,
-    "application_id": 596551,
     "in_reply_to_id": null
   },
   "media_attachments": []

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -117,7 +117,6 @@ If scheduled_at is provided, then a ScheduledStatus will be returned instead:
     "poll": null,
     "idempotency": null,
     "in_reply_to_id": null,
-    "application_id": 596551
   },
   "media_attachments": []
 }


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/33159