### PR TITLE
Update hugo to version 0.140.2, GH actions to latest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: "0.130.0"
+          hugo-version: "0.140.0"
           extended: true
 
       - name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: "0.140.0"
+          hugo-version: "0.140.2"
           extended: true
 
       - name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
         run: hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 

--- a/config.toml
+++ b/config.toml
@@ -5,9 +5,11 @@ title = "Mastodon documentation"
 pygmentsCodeFences = true
 pygmentsStyle = "github-dark"
 metaDataFormat = "yaml"
-paginate = 100
 enableGitInfo = true
 disablePathToLower = true
+
+[pagination]
+  pagerSize = 100
 
 [markup]
   [markup.tableOfContents]


### PR DESCRIPTION
Noticed some deprecation noise on recent actions output - https://github.com/mastodon/documentation/actions/runs/12369534530

For hugo itself -- stepped up version by version locally checking for deprecation output and verifying the site looked the same after build at each version bump. Was able to go all the way to latest with only one config/deprecation change needed.

For the GH actions stuff, bumped to latest for each, which should handle deprecations, but not sure how to verify these other than opening PR and watching.

Do we get a per-PR preview build w/ the gh pages config?