### PR TITLE
Fix incorrect `relationship_severance_event` attribute name in notifications documentation

### DIFF
--- a/content/en/entities/Notification.md
+++ b/content/en/entities/Notification.md
@@ -81,7 +81,7 @@ aliases: [
 **Version history:**\
 4.0.0 - added
 
-### `relationship_severance_event` {{%optional%}} {#relationship_severance_event}
+### `event` {{%optional%}} {#relationship_severance_event}
 
 **Description:** Summary of the event that caused follow relationships to be severed. Attached when `type` of the notification is `severed_relationships`.\
 **Type:** [RelationshipSeveranceEvent]({{< relref "entities/RelationshipSeveranceEvent" >}})\


### PR DESCRIPTION
See https://github.com/mastodon/mastodon/issues/33411