### PR TITLE
Draw attention to CORS requirements for WebFinger

### DIFF
--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -34,6 +34,10 @@ location /.well-known/webfinger {
 }
 ```
 
+{{< hint style="info" >}}
+You must serve the redirect with CORS headers; otherwise, some functions of Mastodon's web UI will not work. For example: `Access-Control-Allow-Origin: *`
+{{</ hint >}}
+
 #### `ALTERNATE_DOMAINS`
 
 If you have multiple domains pointed at your Mastodon server, this setting will allow Mastodon to recognize itself when users are addressed using those other domains. Separate the domains by commas, e.g. `foo.com,bar.com`


### PR DESCRIPTION
Adds a callout box mentioning that CORS headers must be set if WebFinger requests are being redirected to support a customised WEB_DOMAIN value.

This requirement is not called out in the text (only the nginx config example next to it), and is non-obvious enough that, anecdotally, many servers do not implement it properly.

See: https://github.com/mastodon/mastodon/issues/26995