### PR TITLE
Add explanation of rate limit in scheduled status entity

### DIFF
--- a/content/en/entities/ScheduledStatus.md
+++ b/content/en/entities/ScheduledStatus.md
@@ -196,7 +196,7 @@ Returned from `GET /api/v1/scheduled_statuses`:
 
 #### `params[with_rate_limit]` {#params-with_rate_limit}
 
-**Description:** Whether the status should be rate limited <!-- TODO: What does this mean -->.\
+**Description:** Whether the status should be rate limited (defaults to true, controls whether to apply status creation rate limit).\
 **Type:** Boolean\
 **Version history:**\
 2.7.0 - added

--- a/content/en/entities/ScheduledStatus.md
+++ b/content/en/entities/ScheduledStatus.md
@@ -194,9 +194,9 @@ Returned from `GET /api/v1/scheduled_statuses`:
 **Version history:**\
 2.7.0 - added
 
-#### `params[with_rate_limit]` {#params-with_rate_limit}
+#### `params[with_rate_limit]` {{%deprecated%}} {#params-with_rate_limit}
 
-**Description:** Whether the status should be rate limited (defaults to true, controls whether to apply status creation rate limit).\
+**Description:** Whether status creation is subject to rate limiting. Provided for historical compatibility only and can be ignored.\
 **Type:** Boolean\
 **Version history:**\
 2.7.0 - added


### PR DESCRIPTION
Noticed this TODO when doing other change.

Not sure how to add nuance here between "the request level rate limit" and "the model level rate limit". First pass here.