### PR TITLE
provide default matching expected format

### DIFF
--- a/content/en/admin/optional/object-storage.md
+++ b/content/en/admin/optional/object-storage.md
@@ -53,8 +53,8 @@ To enable S3 storage, set the `S3_ENABLED` environment variable to `true`.
 
 - `S3_REGION` (defaults to 'us-east-1', required if using AWS S3, may
   not be required with other storage providers)
-- `S3_ENDPOINT` (defaults to 's3.<S3_REGION>.amazonaws.com', required
-  if not using AWS S3)
+- `S3_ENDPOINT` (defaults to 'https://s3.<S3_REGION>.amazonaws.com',
+  required if not using AWS S3)
 - `S3_BUCKET=mastodata` (replacing `mastodata` with the name of your
   bucket)
 - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` need to be set to


### PR DESCRIPTION
After encountering issues with setting up S3 myself, I deem the default provided on `S3_ENDPOINT` as misleading. Before, I have been using a custom hostname, only, resulting in lots of warnings in the log reading `expected :endpoint to be a HTTP or HTTPS endpoint`.