### PR TITLE
fix(i18n): Use localized translated date for last page update…

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -4,9 +4,6 @@ other = "Improve this page"
 [lastUpdated]
 other = "Last updated"
 
-[lastUpdatedDateFormat]
-other = "{{ .Format \"January 2, 2006\" }}"
-
 [joinTitle]
 other = "Join the social media revolution"
 

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -4,9 +4,6 @@ other = "このページを改善する"
 [lastUpdated]
 other = "最終更新"
 
-[lastUpdatedDateFormat]
-other = "{{ .Format \"January 2, 2006\" }}"
-
 [joinTitle]
 other = "ソーシャルメディア革命に参加する"
 

--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -4,9 +4,6 @@ other = "Popraw tę stronę"
 [lastUpdated]
 other = "Ostatnio aktualizowano"
 
-[lastUpdatedDateFormat]
-other = "{{ .Format \"January 2, 2006\" }}"
-
 [joinTitle]
 other = "Przyłącz się do rewolucji w mediach społecznościowych"
 

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -4,9 +4,6 @@ other = "改进此页面"
 [lastUpdated]
 other = "最后更新于"
 
-[lastUpdatedDateFormat]
-other = "{{ .Format \"January 2, 2006\" }}"
-
 [joinTitle]
 other = "加入社交媒体革命"
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,7 +11,7 @@
     {{ .Content }}
 
     <p style="color: #606085;">
-      {{ i18n "lastUpdated" }} {{ .Lastmod.Format "January 2, 2006" }}{{ with .File }} · <a href='https://github.com/mastodon/documentation/tree/main/content/{{ page.Language.Lang }}/{{ .Path }}' style="color: #606085;">{{ i18n "improvePage" }}{{ end }}</a>
+      {{ i18n "lastUpdated" }} {{ .Lastmod | time.Format ":date_long" }}{{ with .File }} · <a href='https://github.com/mastodon/documentation/tree/main/content/{{ page.Language.Lang }}/{{ .Path }}' style="color: #606085;">{{ i18n "improvePage" }}{{ end }}</a>
 
       {{ if .IsTranslated }}
         <br />

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,7 +11,7 @@
     {{ .Content }}
 
     <p style="color: #606085;">
-      {{ i18n "lastUpdated" }} {{ i18n "lastUpdatedDateFormat"  .Lastmod }}{{ with .File }} · <a href='https://github.com/mastodon/documentation/tree/main/content/{{ page.Language.Lang }}/{{ .Path }}' style="color: #606085;">{{ i18n "improvePage" }}{{ end }}</a>
+      {{ i18n "lastUpdated" }} {{ .Lastmod | time.Format ":date_long" }}{{ with .File }} · <a href='https://github.com/mastodon/documentation/tree/main/content/{{ page.Language.Lang }}/{{ .Path }}' style="color: #606085;">{{ i18n "improvePage" }}{{ end }}</a>
 
       {{ if .IsTranslated }}
         <br />


### PR DESCRIPTION
I noticed the date was not translated.

It should be fixed with the use of [time.Format](https://gohugo.io/functions/time/format/#localization). With japanese as example…

Before:

> 最終更新 December 21, 2022 · [このページを改善する](https://github.com/mastodon/documentation/tree/main/content/ja/_index.md)

After: 

> 最終更新 2022年12月21日 · [このページを改善する](https://github.com/mastodon/documentation/tree/main/content/ja/_index.md)