### PR TITLE
Fetch all replies docs

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -1035,3 +1035,9 @@ main {
     margin-left: 0.25em;
   }
 }
+
+sup {
+  position: relative;
+  top: -0.4em;
+  font-size: 0.8em;
+}

--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -46,7 +46,7 @@ If you have multiple domains pointed at your Mastodon server, this setting will 
 
 Comma-separated list of private IP addresses/subnets that are allowed in outgoing HTTP requests. Mastodon blocks HTTP requests to hosts on private IP address ranges (like `127.0.0.1` or `192.168.1.1/16`) to prevent [Server-side request forgeries](https://en.wikipedia.org/wiki/Server-side_request_forgery). This setting removes the specified IP addresses/subnets from being blocked.
 
-#### `AUTHORIZED_FETCH`
+#### `AUTHORIZED_FETCH` {#authorized-fetch}
 
 Also called "secure mode". When set to `true`, the following changes occur:
 
@@ -1135,6 +1135,67 @@ Regeneration of home feeds is computationally expensive, if your Sidekiq is cons
 {{< hint style="info" >}}
 This setting has no relation to which users are considered active for the purposes of statistics, such as the Monthly Active Users number.
 {{</ hint >}}
+
+### Fetch All Replies {#fetch-all-replies}
+
+**Version history:**\
+4.x.x - added
+
+Fetch all replies fetches the tree of replies beneath an expanded post by recursively requesting the [replies collections](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-replies) of each of the statuses, and then requesting the status itself. Fetching replies is triggered by requesting the status's `context` - so will be triggered both from the web interface and external apps.
+
+Specifically, posts will be fetched if
+- The remote server correctly implements [ActivityPub/ActivityStreams Collections](https://www.w3.org/TR/activitypub/#collections), including [paging](https://www.w3.org/TR/activitystreams-core/#paging)
+- The remote server allows requests for replies collections to be made from the default instance actor - e.g. [`AUTHORIZED_FETCH`](#authorized-fetch) is not enabled
+- The post is "public" or "unlisted" visibility, or equivalent in other apps.
+- Either
+  - The status does not exist in the database OR
+  - The status has not been fetched in `FETCH_REPLIES_COOLDOWN_MINUTES` AND
+  - The status was created more than `FETCH_REPLIES_INITIAL_WAIT_MINUTES` ago
+
+All visibility systems still apply - fetched replies will not be visible to accounts that are e.g. blocked by the post author if the fetching server is well behaved.
+
+When fetching, posts from accounts that have no local followers are refetched as well, even if they are not listed in the parent status's `replies` collection. Since the account has no local followers, the fetching instance would not have received a `Delete` activity, so if on refetching the remote instance returns a `404`, the previously fetched status will be removed.
+
+The need for and cost of fetching replies is likely to vary dramatically for servers of different sizes, so these configuration options allow server admins to tune resource usage: smaller instances may want to increase the limits, while larger instances may want to decrease them or lengthen the cooldown intervals.
+
+#### `FETCH_REPLIES_ENABLED`
+
+**Default:** `true`
+
+Enable or disable fetching additional replies when a post's detailed view is expanded.
+
+#### `FETCH_REPLIES_COOLDOWN_MINUTES`
+
+**Default:** `15`
+
+The amount of time to wait since the last fetch of a post and its replies since the last fetch. 
+
+Note that this applies per-status: triggering a fetch for a parent status and then triggering a reply for a child within the reply tree will not double-fetch the status.
+
+#### `FETCH_REPLIES_INITIAL_WAIT_MINUTES`
+
+**Default:** `5`
+
+The amount of time after a post was created to wait before it is eligible for fetching replies
+
+#### `FETCH_REPLIES_MAX_GLOBAL`
+
+**Default:** `1000`
+
+The maximum number of replies to fetch - total, recursively through a whole reply tree, per fetch action.
+
+#### `FETCH_REPLIES_MAX_SINGLE`
+
+**Default:** `500`
+
+The maximum number of replies to fetch for a single status within a reply tree.
+
+#### `FETCH_REPLIES_MAX_PAGES`
+
+**Default:** `500`
+
+The total number of ActivityPub `Collection` pages to fetch from a whole reply tree, per fetch action.
+
 
 ## Other {#other}
 

--- a/content/en/user/network.md
+++ b/content/en/user/network.md
@@ -11,7 +11,7 @@ menu:
 
 {{< figure src="assets/timeline.png" width="70%" caption="Posts from other servers being streamed into the Live Feed" >}}
 
-To allow you to discover potentially interesting content, Mastodon provides a way to browse all public posts. Well, there is no global shared state between all servers, so there is no way to browse _all_ public posts. When you browse **Live Feeds** > **Other Servers**, you see all public posts that the server you are on knows about. There are various ways your server may discover posts, but the bulk of them will be from people that other users on your server follow.
+To allow you to discover potentially interesting content, Mastodon provides a way to browse all public posts. Well, there is no global shared state between all servers, so there is no way to browse _all_ public posts. When you browse **Live Feeds** > **Other Servers**, you see all public posts that the server you are on knows about. There are [various](#fetching-replies) [ways](#search) your server may discover posts, but the bulk of them will be from people that other users on your server follow. 
 
 You can also filter the Live Feeds to view only public posts created on your server.
 
@@ -26,6 +26,18 @@ You can perform quick actions on a post directly from the timeline, or you can c
 * **Favourite** a post by clicking the star icon. The post will be added to your favourites list, and a favourite notification will be delivered to its author.
 * **Bookmark** a post by clicking the ribbon icon. The post will be privately added to your bookmarks list without generating a notification.
 * Access a **menu** of additional options by clicking the ellipsis icon.
+
+### Fetching Replies {#fetching-replies}
+
+When a status is expanded[^expanded], [if enabled]({{< ref "/admin/config#fetch-all-replies" >}}), your server will attempt to fetch any replies that it does not already know about from other servers. This involves "walking" down the tree of replies and asking each different server for the replies it knows about, so it may take some time, especially for posts with many replies, or if it is the first time the post has been expanded on your server. Try refreshing the page after a few moments if you suspect you aren't seeing all replies.[^retrigger]
+
+Fetching replies will show you most, though not necessarily _all_ replies. Followers-only statuses, direct mentions, and posts from instances that [require authorization]({{< ref "/admin/config#authorized-fetch" >}}) to fetch posts will not be included, unless you or someone else on your server already follows the authoring account.
+
+By [searching](#search) for a post and then expanding it, you can effectively "import" a tree of replies to your instance, helping you and others on your server meet new people and other fediverse creatures!
+
+[^expanded]: "Expanded" in the sense used above, meaning clicking on it to display the detailed view, not e.g. expanding content warnings or unfiltering posts.
+
+[^retrigger]: Refreshing the page will not retrigger a fetch within some cooldown period, so don't worry about overdoing it!
 
 ## Notifications {#notifications}
 


### PR DESCRIPTION
Accompanies: https://github.com/mastodon/mastodon/pull/32615

Tried to split it into user-focused and admin-focused docs, but not exactly sure if i got the location right for either. 

It seems like we need a "FAQ" section for stuff like "can i see everyone's posts!!?!?" or "why are some posts not shown in my instance!?!?!" I can start that if y'all think that's a good idea. Not sure if hugo can make indices, but this would be a great place for them, since this is an extremely common question for new fedis and probably would benefit from multiple points of discoverability.

I also am not sure how frequently footnotes are used in the docs, but i'm a footnotes fiend. Noticed that footnote links were not being rendered as superscripts, so added that (in a way that doesn't expand the line height for lines where footnotes are used).

Opening as a draft since it's not merged yet, and I'm not sure what version it will be deployed in. Couldn't find contributing docs for the docs, so lmk if i'm missing some stuff here <3

Before merging:
- [ ] Add version added in config page