### PR TITLE
Add API Versions page

### DIFF
--- a/content/en/api/versions.md
+++ b/content/en/api/versions.md
@@ -1,0 +1,47 @@
+---
+title: API Versions
+description: How to detect new features within the Mastodon API.
+menu:
+  docs:
+    weight: 40
+    parent: api
+---
+
+Since Mastodon version 4.3.0, the [Instance Details]({{< relref "methods/instance#v2" >}}) endpoint has returned a property indicating the Mastodon API Version, which is separate from the release number, and is just an integer that can be used to detect the presence of new methods or properties on the Mastodon API.
+
+```json
+// GET /api/v2/instance
+{
+  // ...
+  "api_versions": {
+    "mastodon": 5,
+  },
+  // ...
+}
+```
+
+## Changelog
+### Version 1
+
+- *None*
+
+### Version 2
+
+- Grouped notifications API: https://github.com/mastodon/mastodon/pull/31840
+
+### Version 3
+
+- API for updating attribution domains: https://github.com/mastodon/mastodon/pull/32730
+
+### Version 4
+
+- Media deletion methods: https://github.com/mastodon/mastodon/pull/34035
+
+### Version 5
+
+- `blur` filter for media attachments:
+  https://github.com/mastodon/mastodon/pull/34256
+
+---
+
+When the Mastodon API gains new features in the future, this version number will be updated, and this page updated accordingly.

--- a/content/en/methods/instance.md
+++ b/content/en/methods/instance.md
@@ -29,7 +29,8 @@ Obtain general information about the server.
 **OAuth:** Public\
 **Version history:**\
 4.0.0 - added\
-4.3.0 - added `configuration.vapid.public_key`
+4.3.0 - added `configuration.vapid.public_key`\
+4.3.0 - added `api_versions.mastodon`, see [API Versions]({{< relref "api/versions" >}}) and [Instance]({{< relref "entities/Instance#api_versions" >}}) for more info.
 
 #### Response
 
@@ -143,6 +144,9 @@ Obtain general information about the server.
     "enabled": false,
     "approval_required": false,
     "message": null
+  },
+  "api_versions": {
+    "mastodon": 5
   },
   "contact": {
     "email": "staff@mastodon.social",


### PR DESCRIPTION
Currently many of the features listed do not have actual documentation written for them yet, so I've gone with linking to the PRs instead, which is the same as what @cheeaun had.