### PR TITLE
Admin::Measure: fix type description

### DIFF
--- a/content/en/entities/Admin_Measure.md
+++ b/content/en/entities/Admin_Measure.md
@@ -62,8 +62,8 @@ aliases: [
 
 #### `data[][date]` {#data-date}
 
-**Description:** Midnight on the requested day in the time period.\
-**Type:** String ([Datetime](/api/datetime-format#datetime))\
+**Description:** The requested day or midnight on the requested day in the time period.\
+**Type:** String ([Date](/api/datetime-format#date) or [Datetime](/api/datetime-format#datetime))\
 **Version history:**\
 3.5.0 - added
 


### PR DESCRIPTION
Whether `date` is a `Date` or a `Datetime` depends on the requested measure key.