### PR TITLE
Remove installation of `postgresql-contrib` in "System packages" section in install.md

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -48,7 +48,7 @@ apt install -y \
   g++ libprotobuf-dev protobuf-compiler pkg-config gcc autoconf \
   bison build-essential libssl-dev libyaml-dev libreadline6-dev \
   zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev \
-  nginx nodejs redis-server redis-tools postgresql postgresql-contrib \
+  nginx nodejs redis-server redis-tools postgresql \
   certbot python3-certbot-nginx libidn11-dev libicu-dev libjemalloc-dev
 ```
 


### PR DESCRIPTION
The `postgresql-contrib` meta package has been removed with the release of `postgresql-common` v271 in February 2025 (see [here](https://www.postgresql.org/message-id/E1tiZyA-008IKN-8q%40atalia.postgresql.org)) because it's served now by `postgresql`.

Some Linux distros may provide their own `postgresql-contrib` packages, but the Mastodon documentation states that you should use the PGDG APT repository so we should stick to available & supported packages and not mix diffrent repositories for the same component.