### PR TITLE
fix: Remove "attribution_domains" from vanilla account example

### DIFF
--- a/content/en/entities/Account.md
+++ b/content/en/entities/Account.md
@@ -39,7 +39,6 @@ aliases: [
   "locked": false,
   "bot": false,
   "created_at": "2017-02-08T02:00:53.274Z",
-  "attribution_domains": ["example.com", "example.net"],
   "note": "<p>:ms_rainbow_flag:​ :ms_bisexual_flagweb:​ :ms_nonbinary_flag:​ <a href=\"https://awoo.space/tags/awoo\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>awoo</span}.space <a href=\"https://awoo.space/tags/admin\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>admin</span} ~ <a href=\"https://awoo.space/tags/bi\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>bi</span} ~ <a href=\"https://awoo.space/tags/nonbinary\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>nonbinary</span} ~ compsci student ~ likes video <a href=\"https://awoo.space/tags/games\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>games</span} and weird/ old electronics and will post obsessively about both ~ avatar by <span class=\"h-card\"><a href=\"https://weirder.earth/@dzuk\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>dzuk</span}</span></p>",
   "url": "https://awoo.space/@noiob",
   "avatar": "https://files.mastodon.social/accounts/avatars/000/023/634/original/6ca8804dc46800ad.png",


### PR DESCRIPTION
According to the documentation, and inspecting API output from mastodon.social, the `attribution_domains` property is only included in `CredentialAccount`, not `Account`.

This document has example JSON output for both `Account` and `CredentialAccount`, and `attribution_domains` appears in both.

Correct the `Account` example and remove `attribution_domains`.