### PR TITLE
fix: `update_credentials` returns a `CredentialAccount`

### DIFF
--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -314,7 +314,7 @@ PATCH /api/v1/accounts/update_credentials HTTP/1.1
 
 Update the user's display and preferences.
 
-**Returns:** the user's own [Account]({{< relref "entities/Account">}}) with [`source`]({{< relref "entities/Account#source">}}) attribute\
+**Returns:** [CredentialAccount]({{< relref "entities/Account#CredentialAccount">}})\
 **OAuth:** User token + `write:accounts`\
 **Version history:**\
 1.1.1 - added\


### PR DESCRIPTION
Previous documentation only mentioned the `source` property. `update_credentials` actually returns a `CredentialAccount`.

See https://github.com/mastodon/mastodon/blob/82688387a8d19906371a6dd4af64e5b662031603/app/controllers/api/v1/accounts/credentials_controller.rb#L18