### PR TITLE
Align OAuth requirements for GET /api/v1/statuses/:id/source

### DIFF
--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -1875,7 +1875,7 @@ GET /api/v1/statuses/:id/source HTTP/1.1
 Obtain the source properties for a status so that it can be edited.
 
 **Returns:** [StatusSource]({{< relref "entities/statussource" >}})\
-**OAuth:** App token + `read:statuses`\
+**OAuth:** user token + `read:statuses`\
 **Version history:**\
 3.5.0 - added
 


### PR DESCRIPTION
This relates to https://github.com/mastodon/mastodon/issues/34827

However, based on the Headers section, I think this was always meant to be a user token and not an app token.