### PR TITLE
Fix the link in "Unfeature account from profile"

### DIFF
--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -2158,7 +2158,7 @@ Can sometimes be returned if the account already endorsed.
 
 ---
 
-## Unfeature account from profile {#unpin}
+## Unfeature account from profile {#unendorse}
 
 ```http
 POST /api/v1/accounts/:id/unendorse HTTP/1.1


### PR DESCRIPTION
[https://docs.joinmastodon.org/methods/accounts/#unpin](https://docs.joinmastodon.org/methods/accounts/#unpin) points to two things, a deprecated API route and a non-deprecated API route. This PR separates the two by changing the non-deprecated's ID to `unendorse`