### PR TITLE
Mark MediaAttachment#meta as nullable

### DIFF
--- a/content/en/entities/MediaAttachment.md
+++ b/content/en/entities/MediaAttachment.md
@@ -200,7 +200,7 @@ aliases: [
 ### `meta` {#meta}
 
 **Description:** Metadata returned by Paperclip.\
-**Type:** Hash\
+**Type:** {{<nullable>}} Hash or null\
 **Version history:**\
 1.5.0 - added
 


### PR DESCRIPTION
I've experienced errors from meta being null a number of times.