### PR TITLE
Add reference to AP Miscellany report in ActivityPub spec documentation

### DIFF
--- a/content/en/spec/activitypub.md
+++ b/content/en/spec/activitypub.md
@@ -318,7 +318,7 @@ Contains terms used for Mastodon features.
 
 Base URI: `https://www.w3.org/ns/activitystreams#`
 
-Contains ActivityStreams extended properties that have been proposed but not officially adopted yet.
+Contains ActivityStreams extended properties that have been proposed but not officially adopted yet. These have now been documented by the [ActivityPub Miscellaneous Terms](https://swicg.github.io/miscellany/) document.
 
 - as:Hashtag (`https://www.w3.org/ns/activitystreams#Hashtag`)
 - as:manuallyApprovesFollowers (`https://www.w3.org/ns/activitystreams#manuallyApprovesFollowers`)


### PR DESCRIPTION
These were defined in a document a little while ago, despite originating in Mastodon: https://swicg.github.io/miscellany/