### PR TITLE
Update package names and dependencies in "Installing from source"

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -19,7 +19,7 @@ You will be running the commands as root. If you aren’t already root, switch t
 
 ### System repositories {#system-repositories}
 
-Make sure curl, wget, gnupg, apt-transport-https, lsb-release and ca-certificates are installed first:
+Make sure curl, wget, gnupg, lsb-release and ca-certificates are installed first:
 
 ```bash
 apt install -y curl wget gnupg lsb-release ca-certificates

--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -22,7 +22,7 @@ You will be running the commands as root. If you aren’t already root, switch t
 Make sure curl, wget, gnupg, apt-transport-https, lsb-release and ca-certificates are installed first:
 
 ```bash
-apt install -y curl wget gnupg apt-transport-https lsb-release ca-certificates
+apt install -y curl wget gnupg lsb-release ca-certificates
 ```
 
 #### Node.js {#node-js}
@@ -44,12 +44,11 @@ echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] http://apt.postgresql.o
 ```bash
 apt update
 apt install -y \
-  imagemagick ffmpeg libvips-tools libpq-dev libxml2-dev libxslt1-dev file git-core \
-  g++ libprotobuf-dev protobuf-compiler pkg-config gcc autoconf \
-  bison build-essential libssl-dev libyaml-dev libreadline6-dev \
-  zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev \
-  nginx nodejs redis-server redis-tools postgresql \
-  certbot python3-certbot-nginx libidn11-dev libicu-dev libjemalloc-dev
+  imagemagick ffmpeg libvips-tools libpq-dev libxslt1-dev file git \
+  protobuf-compiler pkg-config autoconf bison build-essential \
+  libssl-dev libyaml-dev libreadline-dev zlib1g-dev libffi-dev \
+  libgdbm-dev nginx nodejs redis-server postgresql certbot \
+  python3-certbot-nginx libidn-dev libicu-dev libjemalloc-dev
 ```
 
 #### Yarn {#yarn}


### PR DESCRIPTION
Updates the installation instructions for upstream package removals and renames that happened years before the required versions of ubuntu and debian in the doc. Also updates the list of system packages to remove redundant dependencies that are already pulled in by the explicitly installed packages.

**System repositories** section:

- `apt-transport-https` was removed upstream years ago; this is just a transitional package that doesn't install anything, since `apt` already supports https.

**System packages** section:

- `libxslt1-dev` pulls in `libxml2-dev`
- `git-core` was renamed `git`
- `build-essential` pulls in `g++` and `gcc`
- `protobuf-compiler` pulls in `libprotobuf-dev`
- `libreadline6-dev` was renamed `libreadline-dev`
- `libreadline-dev` pulls in `libncurses-dev` (also renamed from `libncurses5-dev`)
- `redis-server` pulls in `redis-tools`
- `libidn11-dev` was renamed `libidn-dev`