### PR TITLE
Updated Bug Bounty Page

### DIFF
--- a/content/en/dev/disclosure.md
+++ b/content/en/dev/disclosure.md
@@ -1,16 +1,16 @@
 ---
-title: Bug bounties and responsible disclosure
-description: What to do if you found a serious bug
+title: Bug bounties and Coordinated Vulnerability Disclosures
+description: What to do if you believe that you've found a security bug.
 menu:
   docs:
     weight: 9999
     parent: dev
 ---
 
-If you believe you've identified a security vulnerability in Mastodon (a bug that allows something to happen that shouldn't be possible), you should send the report to **security@joinmastodon.org**. We will gladly reward such reports in proportion to the severity of the issue through our OpenCollective fund.
-
-You should *not* report such issues on GitHub or in other public spaces to give us time to publish a fix for the issue without exposing Mastodon's users to increased risk.
+If you believe that you've identified a [security vulnerability](https://csrc.nist.gov/glossary/term/vulnerability) in Mastodon, we encourage you to submit the bug to us privately for [coordinated vulnerability disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure). We do **not** recommend that you report such issues publicly on GitHub or in other public spaces, until we've had time to publish a patch for the issue without exposing Mastodon's users to increased risk. Should you choose to coordinate disclosure, we may credit you for your discovery, and financially reward you in proportion to the severity of the issue through our [OpenCollective fund](https://opencollective.com/mastodon).
 
 {{< hint style="info" >}}
-A "vulnerability in Mastodon" is a vulnerability in the code distributed through our main source code repository on GitHub. Vulnerabilities that are specific to a given installation (e.g. misconfiguration) should be reported to the owner of that installation and not us.
+A "vulnerability in Mastodon" is a vulnerability in the code distributed through [one of our public source code repositories on GitHub](https://github.com/orgs/mastodon/repositories?q=visibility%3Apublic%20archived%3Afalse%20-fork%3Atrue). Vulnerabilities that are specific to a given Mastodon instance installation (e.g. misconfiguration) should be reported to the owner of that Mastodon instance. To find a Mastodon instance's contact information, visit their respective `/about` page.
 {{< /hint >}}
+
+**To submit a bug, please review our [Security Policy page](https://github.com/mastodon/mastodon/security) or send an email to [security@joinmastodon.org](mailto:security@joinmastodon.org)**


### PR DESCRIPTION
Streamlined the language of the bug bounty page and updated wording to reflect "coordinated disclosure" is the preferred path. Also added relevant links to OpenCollective fund and other existing resources.