### PR TITLE
Languages is not mandatory in follow / unfollow API calls,…

### DIFF
--- a/content/en/entities/Relationship.md
+++ b/content/en/entities/Relationship.md
@@ -66,7 +66,7 @@ aliases: [
 ### `languages` {#languages}
 
 **Description:** Which languages are you following from this user?\
-**Type:** Array of String (ISO 639-1 language two-letter code)\
+**Type:** {{<nullable>}} Array of String(ISO 639-1 language two-letter code), or null \
 **Version history:**\
 4.0.0 - added
 


### PR DESCRIPTION
… so I guess languages may be null in Relationship model?

We found that documentation issue while debugging [this client API](https://github.com/vazaha-nl/mastodon-api-client/issues/7#issuecomment-3208237306) (which is based automatically on Mastodon documentation) 

This commit just state that languages may be null in the Relationship object, using the same syntax for {{nullable}} as other objects

