### PR TITLE
Add documentation for Mastodon 4.5 quote post features

### DIFF
--- a/content/en/entities/Account.md
+++ b/content/en/entities/Account.md
@@ -470,6 +470,16 @@ aliases: [
 **Version history:**\
 4.3.0 - added
 
+#### `source[quote_policy]` {#source-quote_policy}
+
+**Description:** The default quote policy to be used for new statuses.\
+**Type:** String (Enumerable, oneOf)\
+`public` = Anyone (except blocked accounts) can quote\
+`followers` = Only followers and author can quote\
+`nobody` = Only author can quote\
+**Version history:**\
+4.5.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 7) - added `posting:default:quoted_policy`
+
 ### `role` {#role}
 
 **Description:** The complete role assigned to the currently authorized user, including permissions and highlighted status.\

--- a/content/en/entities/Notification.md
+++ b/content/en/entities/Notification.md
@@ -37,6 +37,8 @@ aliases: [
 `admin.report` = A new report has been filed\
 `severed_relationships` = Some of your follow relationships have been severed as a result of a moderation or block event\
 `moderation_warning` = A moderator has taken action against your account or has sent you a warning\
+`quote` = Someone has quoted one of your statuses\
+`quoted_update` = A status you have quoted has been edited\
 **Version history:**\
 0.9.9 - added\
 2.8.0 - added `poll`\
@@ -44,7 +46,8 @@ aliases: [
 3.3.0 - added `status`\
 3.5.0 - added `update` and `admin.sign_up`\
 4.0.0 - added `admin.report`\
-4.3.0 - added `severed_relationships` and `moderation_warning`
+4.3.0 - added `severed_relationships` and `moderation_warning`\
+4.5.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 7) - added `quote` and `quoted_update`
 
 ### `group_key` {#group_key}
 
@@ -69,7 +72,7 @@ aliases: [
 
 ### `status` {{%optional%}} {#status}
 
-**Description:** Status that was the object of the notification. Attached when `type` of the notification is `favourite`, `reblog`, `status`, `mention`, `poll`, or `update`.\
+**Description:** Status that was the object of the notification. Attached when `type` of the notification is `favourite`, `reblog`, `status`, `mention`, `poll`, `update`, `quote` or `quoted_update`. In the case of `quoted_update`, your quote of the edited status is attached, not the status that was edited.\
 **Type:** [Status]({{< relref "entities/Status" >}})\
 **Version history:**\
 0.9.9 - added

--- a/content/en/entities/QuoteApproval.md
+++ b/content/en/entities/QuoteApproval.md
@@ -1,0 +1,53 @@
+---
+title: QuoteApproval
+description: Summary of a status' quote approval policy and how it applies to the requesting user.
+menu:
+  docs:
+    parent: entities
+aliases: [
+	"/entities/quote_approval",
+]
+---
+
+## Example
+
+```json
+{
+  "automatic": ["public"],
+  "manual": [],
+  "current_user": "automatic"
+}
+```
+
+## Attributes
+
+### `automatic` {#automatic}
+
+**Description:** Describes who is expected to be able to quote that status and have the quote automatically authorized. An empty list means that nobody is expected to be able to quote this post.\
+**Type:** Array of String (Enumerable, anyOf)\
+`public` = Anybody is expected to be able to quote this status and have the quote be automatically accepted.\
+`followers` = Followers are expected to be able to quote this status and have the quote be automatically accepted.\
+`unknown` = The underlying quote policy is too complex for Mastodon to represent. Some accounts that do not fit in the above categories may be able to quote and have the quote be automatically accepted.\
+**Version history:**\
+4.5.0 - added
+
+### `manual` {#manual}
+
+**Description:** Describes who is expected to have their quotes of this status be manually reviewed by the author before being accepted. An empty list means that nobody is expected to be able to quote this post.\
+**Type:** Array of String (Enumerable, anyOf)\
+`public` = Anybody is expected to be able to quote this status, but have the quote be accepted only after manual review.\
+`followers` = Followers are expected to be able to quote this status, but have the quote be accepted only after manual review.\
+`unknown` = The underlying quote policy is too complex for Mastodon to represent. Some accounts that do not fit in the above categories may be allowed to quote with manual review.\
+**Version history:**\
+4.5.0 - added
+
+### `current_user` {#current_user}
+
+**Description:** Describes how this status' quote policy applies to the current user.\
+**Type:** String (Enumerable, oneOf)\
+`automatic` = The requesting user is expected to be allowed to quote and have their quote be automatically accepted.\
+`manual` = The requesting user is expected to be allowed to quote after manual review of the post by the quoted status' author.\
+`denied` = The requesting user is not expected to be allowed to quote this post. Mastodon will return an error if you attempt to do so.\
+`unknown` = The underlying quote policy is too complex for Mastodon to represent. This should be treated as `denied` unless you are targeting “power users”.\
+**Version history:**\
+4.5.0 - added

--- a/content/en/entities/QuoteApproval.md
+++ b/content/en/entities/QuoteApproval.md
@@ -23,20 +23,22 @@ aliases: [
 
 ### `automatic` {#automatic}
 
-**Description:** Describes who is expected to be able to quote that status and have the quote automatically authorized. An empty list means that nobody is expected to be able to quote this post.\
+**Description:** Describes who is expected to be able to quote that status and have the quote automatically authorized. An empty list means that nobody is expected to be able to quote this post. Other values may be added in the future, so unknown values should be treated as `unsupported_policy`.\
 **Type:** Array of String (Enumerable, anyOf)\
 `public` = Anybody is expected to be able to quote this status and have the quote be automatically accepted.\
 `followers` = Followers are expected to be able to quote this status and have the quote be automatically accepted.\
+`following` = People followed by the author are expected to be able to quote this status and have the quote be automatically accepted.\
 `unsupported_policy` = The underlying quote policy is not supported by Mastodon. Some accounts that do not fit in the above categories may be able to quote and have the quote be automatically accepted.\
 **Version history:**\
 4.5.0 - added
 
 ### `manual` {#manual}
 
-**Description:** Describes who is expected to have their quotes of this status be manually reviewed by the author before being accepted. An empty list means that nobody is expected to be able to quote this post.\
+**Description:** Describes who is expected to have their quotes of this status be manually reviewed by the author before being accepted. An empty list means that nobody is expected to be able to quote this post. Other values may be added in the future, so unknown values should be treated as `unsupported_policy`.\
 **Type:** Array of String (Enumerable, anyOf)\
 `public` = Anybody is expected to be able to quote this status, but have the quote be accepted only after manual review.\
 `followers` = Followers are expected to be able to quote this status, but have the quote be accepted only after manual review.\
+`following` = People followed by the author are expected to be able to quote this status, but have the quote be accepted only after manual review.\
 `unsupported_policy` = The underlying quote policy is not supported by Mastodon. Some accounts that do not fit in the above categories may be allowed to quote with manual review.\
 **Version history:**\
 4.5.0 - added

--- a/content/en/entities/QuoteApproval.md
+++ b/content/en/entities/QuoteApproval.md
@@ -27,7 +27,7 @@ aliases: [
 **Type:** Array of String (Enumerable, anyOf)\
 `public` = Anybody is expected to be able to quote this status and have the quote be automatically accepted.\
 `followers` = Followers are expected to be able to quote this status and have the quote be automatically accepted.\
-`unknown` = The underlying quote policy is too complex for Mastodon to represent. Some accounts that do not fit in the above categories may be able to quote and have the quote be automatically accepted.\
+`unsupported_policy` = The underlying quote policy is not supported by Mastodon. Some accounts that do not fit in the above categories may be able to quote and have the quote be automatically accepted.\
 **Version history:**\
 4.5.0 - added
 
@@ -37,7 +37,7 @@ aliases: [
 **Type:** Array of String (Enumerable, anyOf)\
 `public` = Anybody is expected to be able to quote this status, but have the quote be accepted only after manual review.\
 `followers` = Followers are expected to be able to quote this status, but have the quote be accepted only after manual review.\
-`unknown` = The underlying quote policy is too complex for Mastodon to represent. Some accounts that do not fit in the above categories may be allowed to quote with manual review.\
+`unsupported_policy` = The underlying quote policy is not supported by Mastodon. Some accounts that do not fit in the above categories may be allowed to quote with manual review.\
 **Version history:**\
 4.5.0 - added
 
@@ -48,6 +48,6 @@ aliases: [
 `automatic` = The requesting user is expected to be allowed to quote and have their quote be automatically accepted.\
 `manual` = The requesting user is expected to be allowed to quote after manual review of the post by the quoted status' author.\
 `denied` = The requesting user is not expected to be allowed to quote this post. Mastodon will return an error if you attempt to do so.\
-`unknown` = The underlying quote policy is too complex for Mastodon to represent. This should be treated as `denied` unless you are targeting “power users”.\
+`unknown` = The user is not covered by the quote policies supported by Mastodon, and there are additional underlying quote policies that are unsupported by Mastodon. This should be treated as `denied` unless you are targeting “power users”.\
 **Version history:**\
 4.5.0 - added

--- a/content/en/entities/Status.md
+++ b/content/en/entities/Status.md
@@ -226,6 +226,13 @@ aliases: [
 **Version history:**\
 0.1.0 - added
 
+### `quotes_count` {#quotes_count}
+
+**Description:** How many accepted quotes this status has.\
+**Type:** Integer\
+**Version history:**\
+4.5.0 - added
+
 ### `replies_count` {#replies_count}
 
 **Description:** How many replies this status has received.\

--- a/content/en/entities/Status.md
+++ b/content/en/entities/Status.md
@@ -303,6 +303,13 @@ aliases: [
 **Version history:**\
 4.4.0 - added
 
+### `quote_approval` {#quote_approval}
+
+**Description:** Summary of the post quote's approval policy and how it applies to the user making the request, that is, whether the user can be expected to be allowed to quote that post\
+**Type:** [QuoteApproval]({{< relref "entities/QuoteApproval" >}})
+**Version history:**\
+4.5.0 - added
+
 ### `favourited` {{%optional%}} {#favourited}
 
 **Description:** If the current token has an authorized user: Have you favourited this status?\

--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -337,7 +337,8 @@ Update the user's display and preferences.
 2.7.0 - added `discoverable` parameter\
 4.1.0 - added `hide_collections` parameter\
 4.2.0 - added `indexable` parameter\
-4.4.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 3) - added `attribution_domains` parameter
+4.4.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 3) - added `attribution_domains` parameter\
+4.5.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 7) - added `quote_policy` parameter
 
 #### Request
 
@@ -395,6 +396,9 @@ source[sensitive]
 
 source[language]
 : String. Default language to use for authored statuses (ISO 639-1)
+
+source[quote_policy]
+: String (Enumerable, oneOf `public` `followers` `nobody`). Default quote policy for new posts.
 
 #### Response
 

--- a/content/en/methods/grouped_notifications.md
+++ b/content/en/methods/grouped_notifications.md
@@ -591,8 +591,11 @@ TODO
 `admin.report` = A new report has been filed\
 `severed_relationships` = Some of your follow relationships have been severed as a result of a moderation or block event\
 `moderation_warning` = A moderator has taken action against your account or has sent you a warning\
+`quote` = Someone has quoted one of your statuses\
+`quoted_update` = A status you have quoted has been edited\
 **Version history:**\
-4.3.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 2) - added
+4.3.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 2) - added\
+4.5.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 7) - added `quote` and `quoted_update`
 
 #### `most_recent_notification_id`
 
@@ -631,7 +634,7 @@ TODO
 
 #### `status_id` {{%optional%}}
 
-**Description:** ID of the [Status]({{< relref "entities/Status" >}}) that was the object of the notification. Attached when `type` of the notification is `favourite`, `reblog`, `status`, `mention`, `poll`, or `update`.\
+**Description:** ID of the [Status]({{< relref "entities/Status" >}}) that was the object of the notification. Attached when `type` of the notification is `favourite`, `reblog`, `status`, `mention`, `poll`, `update`, `quote` or `quoted_update`. In the case of `quoted_update`, your quote of the edited status is attached, not the status that was edited.\
 **Type:** String\
 **Version history:**\
 4.3.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 2) - added

--- a/content/en/methods/preferences.md
+++ b/content/en/methods/preferences.md
@@ -29,7 +29,8 @@ Preferences defined by the user in their account settings.
 **Returns:** Preferences by key and value\
 **OAuth:** User token + `read:accounts`\
 **Version history:**\
-2.8.0 - added
+2.8.0 - added\
+4.5.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 7) - added `posting:default:quoted_policy`
 
 #### Request
 
@@ -46,6 +47,7 @@ Authorization
   "posting:default:visibility": "public",
   "posting:default:sensitive": false,
   "posting:default:language": null,
+  "posting:default:quote_policy": "followers",
   "reading:expand:media": "default",
   "reading:expand:spoilers": false
 }

--- a/content/en/methods/push.md
+++ b/content/en/methods/push.md
@@ -47,7 +47,8 @@ Add a Web Push API subscription to receive notifications. Each access token can 
 3.5.0 - added `data[alerts][update]` and `data[alerts][admin.sign_up]`\
 4.0.0 - added `data[alerts][admin.report]`\
 4.3.0 - added stricter request parameter validation, invalid endpoint URLs and subscription keys will now result in an error, previously these would be accepted, but silently fail.\
-4.4.0 - added `subscription[standard]`
+4.4.0 - added `subscription[standard]`\
+4.5.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 7)- added `data[alerts][quote]` and `data[alerts][quoted_update]`
 
 #### Request
 
@@ -73,6 +74,9 @@ subscription[standard]
 data[alerts][mention]
 : Boolean. Receive mention notifications? Defaults to false.
 
+data[alerts][quote]
+: Boolean. Receive quote notifications? Defaults to false.
+
 data[alerts][status]
 : Boolean. Receive new subscribed account notifications? Defaults to false.
 
@@ -93,6 +97,9 @@ data[alerts][poll]
 
 data[alerts][update]
 : Boolean. Receive status edited notifications? Defaults to false.
+
+data[alerts][quoted_update]
+: Boolean. Receive quoted status edit notifications? Defaults to false.
 
 data[alerts][admin.sign_up]
 : Boolean. Receive new user signup notifications? Defaults to false. Must have a role with the appropriate permissions.

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -32,7 +32,7 @@ Publish a status with the given parameters.
 0.0.0 - added\
 2.7.0 - `scheduled_at` added\
 2.8.0 - `poll` added
-4.5.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 7) - `quoted_status_id` added
+4.5.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 7) - `quoted_status_id` and `quote_approval_policy` added
 
 #### Request
 
@@ -84,6 +84,12 @@ scheduled_at
 
 quoted_status_id
 : String. ID of the status being quoted, if any. Will raise an error if the status does not exist, the author does not have access to it, or quoting is denied by Mastodon's understanding of the attached quote policy.
+
+quote_approval_policy
+: String (Enumerable, oneOf). Sets who is allowed to quote the status. Ignored if `visibility` is `private` or `direct`, in which case the policy will always be set to `nobody`.\
+`public` = Anyone is allowed to quote this status and will have their quote automatically accepted, unless they are blocked.\
+`followers` = Only followers and the author are allowed to quote this status, and will have their quote automatically accepted.\
+`nobody` = Only the author is allowed to quote the status.
 
 #### Response
 ##### 200: OK
@@ -1599,7 +1605,8 @@ Edit a given status to change its text, sensitivity, media attachments, or poll.
 **OAuth:** User token + `write:statuses`\
 **Version history:**\
 3.5.0 - added\
-4.0.0 - add `language`
+4.0.0 - add `language`\
+4.5.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 7) - add `quote_approval_policy`
 
 #### Request
 
@@ -1644,6 +1651,12 @@ poll[multiple]
 
 poll[hide_totals]
 : Boolean. Hide vote counts until the poll ends? Defaults to false.
+
+quote_approval_policy
+: String (Enumerable, oneOf). Sets who is allowed to quote the status. Ignored if `visibility` is `private` or `direct`, in which case the policy will always be set to `nobody`. Changing the policy does not invalidate past quotes.\
+`public` = Anyone is allowed to quote this status and will have their quote automatically accepted, unless they are blocked.\
+`followers` = Only followers and the author are allowed to quote this status, and will have their quote automatically accepted.\
+`nobody` = Only the author is allowed to quote the status.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -857,7 +857,7 @@ limit
 #### Response
 ##### 200: OK
 
-A list of statuses that quote the requested status
+A list of statuses that quote the requested status.
 
 ```json
 [
@@ -897,7 +897,7 @@ Link: <https://mastodon.example/api/v1/statuses/109404970108594430/quotes?limit=
 
 ##### 404: Not found
 
-Status does not exist or is private
+Status does not exist or is private.
 
 ```json
 {
@@ -907,7 +907,7 @@ Status does not exist or is private
 
 ##### 403: Forbidden
 
-Status is not owned by the requesting user
+Status is not owned by the requesting user.
 
 ```json
 {
@@ -1432,7 +1432,7 @@ Authorization
 #### Response
 ##### 200: OK
 
-An updated Status with the quote revoked
+An updated Status with the quote revoked.
 
 ```json
 {
@@ -1448,7 +1448,7 @@ An updated Status with the quote revoked
 
 ##### 404: Not found
 
-Status does not exist or is private, or no such quote exists
+Status does not exist or is private, or no such quote exists.
 
 ```json
 {
@@ -1458,7 +1458,7 @@ Status does not exist or is private, or no such quote exists
 
 ##### 403: Forbidden
 
-Status is not owned by the requesting user
+Status is not owned by the requesting user.
 
 ```json
 {

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -818,6 +818,115 @@ Status does not exist or is private
 
 ---
 
+## See quotes of a status {#quotes}
+
+```http
+GET /api/v1/statuses/:id/quotes HTTP/1.1
+```
+
+View quotes of a status you have posted.
+
+**Returns:** Array of [Status]({{< relref "entities/status" >}})\
+**OAuth:** User token + `read:statuses`. The user token must be owned by the author of the status.\
+**Version history:**\
+4.5.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 7) - added
+
+#### Request
+
+##### Path parameters
+
+:id
+: {{<required>}} String. The ID of the Status in the database.
+
+##### Headers
+
+Authorization
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
+
+##### Query parameters
+
+max_id
+: **Internal parameter.** Use HTTP `Link` header for pagination.
+
+since_id
+: **Internal parameter.** Use HTTP `Link` header for pagination.
+
+limit
+: Integer. Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
+
+#### Response
+##### 200: OK
+
+A list of statuses that quote the requested status
+
+```json
+[
+  {
+    "id": "115107232286434584",
+    "created_at": "2025-08-28T16:02:57.029Z",
+    "quote": {
+      "state": "accepted",
+      "quoted_status": {
+        "id":"115107231366664709",
+        // ...
+      },
+    },
+    // ...
+  },
+  {
+    "id": "115107231976600838",
+    "created_at": "2025-08-28T16:02:52.302Z",
+    "quote": {
+      "state": "accepted",
+      "quoted_status": {
+        "id":"115107231366664709",
+        // ...
+      },
+    },
+    // ...
+  },
+  // ...
+]
+```
+
+Because quote Status IDs are generally not known ahead of time, you will have to parse the HTTP `Link` header to load older or newer results. See [Paginating through API responses]({{<relref "api/guidelines#pagination">}}) for more information.
+
+```http
+Link: <https://mastodon.example/api/v1/statuses/109404970108594430/quotes?limit=2&max_id=109406336446186031>; rel="next", <https://mastodon.example/api/v1/statuses/109404970108594430/quotes?limit=2&since_id=109408462939099398>; rel="prev"
+```
+
+##### 404: Not found
+
+Status does not exist or is private
+
+```json
+{
+  "error": "Record not found"
+}
+```
+
+##### 403: Forbidden
+
+Status is not owned by the requesting user
+
+```json
+{
+  "error": "This action is not allowed"
+}
+```
+
+##### 401: Unauthorized
+
+Invalid or missing Authorization header.
+
+```json
+{
+  "error": "This method requires an authenticated user"
+}
+```
+
+---
+
 ## See who favourited a status {#favourited_by}
 
 ```http

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -1401,6 +1401,83 @@ Status does not exist or is private.
 
 ---
 
+## Revoke a quote post {#revoke_quote}
+
+```http
+POST /api/v1/statuses/:id/quotes/:quoting_status_id/revoke HTTP/1.1
+```
+
+Revoke quote authorization of status `quoting_status_id`, detaching status `id`.
+
+**Returns:** [Status]({{< relref "entities/status" >}})\
+**OAuth:** User token + `write:statuses`. The user token must be owned by the author of the status `id`.\
+**Version history:**\
+4.5.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 7) - added
+
+#### Request
+
+##### Path parameters
+
+:id
+: {{<required>}} String. The ID of the quoted Status in the database.
+
+:quoting_status_id
+: {{<required>}} String. The ID of the quoting Status in the database.
+
+##### Headers
+
+Authorization
+: Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
+
+#### Response
+##### 200: OK
+
+An updated Status with the quote revoked
+
+```json
+{
+  "id": "115107232286434584",
+  "created_at": "2025-08-28T16:02:57.029Z",
+  "quote": {
+    "state": "revoked",
+    "quoted_status": null,
+  },
+  // ...
+}
+```
+
+##### 404: Not found
+
+Status does not exist or is private, or no such quote exists
+
+```json
+{
+  "error": "Record not found"
+}
+```
+
+##### 403: Forbidden
+
+Status is not owned by the requesting user
+
+```json
+{
+  "error": "This action is not allowed"
+}
+```
+
+##### 401: Unauthorized
+
+Invalid or missing Authorization header.
+
+```json
+{
+  "error": "This method requires an authenticated user"
+}
+```
+
+---
+
 ## Mute a conversation {#mute}
 
 ```http

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -86,7 +86,7 @@ quoted_status_id
 : String. ID of the status being quoted, if any. Will raise an error if the status does not exist, the author does not have access to it, or quoting is denied by Mastodon's understanding of the attached quote policy. All posts except Private Mentions (`direct` visibility) are quotable by their author. Quoting a `private` post will restrict the quoting post's `visibility` to `private` or `direct` (if the given `visibility` is `public` or `unlisted`, `private` will be used instead). If the `status` text doesn't include a link to the quoted post, Mastodon will prepend a `<p class="quote-inline">RE: <a href="…">…</a></p>` paragraph for backward compatibility (such a paragraph will be hidden by Mastodon's web interface).
 
 quote_approval_policy
-: String (Enumerable, oneOf). Sets who is allowed to quote the status. Ignored if `visibility` is `private` or `direct`, in which case the policy will always be set to `nobody`.\
+: String (Enumerable, oneOf). Sets who is allowed to quote the status. When omitted, the user's [default setting](/entities/Account##source-quote_policy) will be used instead. Ignored if `visibility` is `private` or `direct`, in which case the policy will always be set to `nobody`.\
 `public` = Anyone is allowed to quote this status and will have their quote automatically accepted, unless they are blocked.\
 `followers` = Only followers and the author are allowed to quote this status, and will have their quote automatically accepted.\
 `nobody` = Only the author is allowed to quote the status.

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -1923,6 +1923,115 @@ Status does not exist, is private, or is not owned by you.
 
 ---
 
+## Edit a status' interaction policies {#edit_interaction_policy}
+
+```http
+PUT /api/v1/statuses/:id/interaction_policy HTTP/1.1
+```
+
+Edit a given status to change its interaction policies. Currently, this means changing its quote approval policy.
+
+**Returns:** [Status]({{< relref "entities/status" >}})\
+**OAuth:** User token + `write:statuses`\
+**Version history:**\
+4.5.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 7) - added
+
+#### Request
+
+##### Path parameters
+
+:id
+: {{<required>}} String. The ID of the Status in the database.
+
+##### Headers
+
+Authorization
+: {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
+
+##### Form data parameters
+
+quote_approval_policy
+: String (Enumerable, oneOf). Sets who is allowed to quote the status. Ignored if `visibility` is `private` or `direct`, in which case the policy will always be set to `nobody`. Changing the policy does not invalidate past quotes.\
+`public` = Anyone is allowed to quote this status and will have their quote automatically accepted, unless they are blocked.\
+`followers` = Only followers and the author are allowed to quote this status, and will have their quote automatically accepted.\
+`nobody` = Only the author is allowed to quote the status.
+
+#### Response
+##### 200: OK
+
+Status has been successfully edited.
+
+```json
+{
+  "id": "108942703571991143",
+  "created_at": "2022-09-04T23:22:13.704Z",
+  "in_reply_to_id": null,
+  "in_reply_to_account_id": null,
+  "sensitive": false,
+  "spoiler_text": "",
+  "visibility": "public",
+  "language": "en",
+  "uri": "https://mastodon.social/users/trwnh/statuses/108942703571991143",
+  "url": "https://mastodon.social/@trwnh/108942703571991143",
+  "replies_count": 3,
+  "reblogs_count": 1,
+  "favourites_count": 6,
+  "edited_at": "2022-09-05T00:33:20.309Z",
+  "favourited": false,
+  "reblogged": false,
+  "muted": false,
+  "bookmarked": false,
+  "pinned": false,
+  "content": "<p>this is a status that has been edited multiple times to change the text, add a poll, and change poll options.</p>",
+  "filtered": [],
+  "reblog": null,
+  "application": {
+    "name": "SubwayTooter",
+    "website": null
+  },
+  "account": {
+    "id": "14715",
+    "username": "trwnh",
+    "acct": "trwnh",
+    "display_name": "infinite love ⴳ",
+    // ...
+  },
+  "media_attachments": [],
+  "mentions": [],
+  "tags": [],
+  "emojis": [],
+  "card": null,
+  "poll": null,
+  "quote_approval": {
+    "automatic": ["public"],
+    "manual": [],
+    "current_user": "automatic",
+  }
+}
+```
+
+##### 401: Unauthorized
+
+Invalid or missing Authorization header.
+
+```json
+{
+  "error": "The access token is invalid"
+}
+```
+
+##### 404: Not found
+
+Status does not exist, is private, or is not owned by you.
+
+```json
+{
+  "error": "Record not found"
+}
+```
+
+---
+
 ## View edit history of a status {#history}
 
 ```http

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -83,7 +83,7 @@ scheduled_at
 : String. [Datetime](/api/datetime-format#datetime) at which to schedule a status. Providing this parameter will cause ScheduledStatus to be returned instead of Status. Must be at least 5 minutes in the future.
 
 quoted_status_id
-: String. ID of the status being quoted, if any. Will raise an error if the status does not exist, the author does not have access to it, or quoting is denied by Mastodon's understanding of the attached quote policy. All posts except Private Mentions (`direct` visibility) are quotable by their author. Quoting a `private` post will restrict the quoting post's `visibility` to `private` or `direct` (if the given `visibility` is `public` or `unlisted`, `private` will be used instead).
+: String. ID of the status being quoted, if any. Will raise an error if the status does not exist, the author does not have access to it, or quoting is denied by Mastodon's understanding of the attached quote policy. All posts except Private Mentions (`direct` visibility) are quotable by their author. Quoting a `private` post will restrict the quoting post's `visibility` to `private` or `direct` (if the given `visibility` is `public` or `unlisted`, `private` will be used instead). If the `status` text doesn't include a link to the quoted post, Mastodon will prepend a `<p class="quote-inline">RE: <a href="…">…</a></p>` paragraph for backward compatibility (such a paragraph will be hidden by Mastodon's web interface).
 
 quote_approval_policy
 : String (Enumerable, oneOf). Sets who is allowed to quote the status. Ignored if `visibility` is `private` or `direct`, in which case the policy will always be set to `nobody`.\

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -32,6 +32,7 @@ Publish a status with the given parameters.
 0.0.0 - added\
 2.7.0 - `scheduled_at` added\
 2.8.0 - `poll` added
+4.5.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 7) - `quoted_status_id` added
 
 #### Request
 
@@ -80,6 +81,9 @@ language
 
 scheduled_at
 : String. [Datetime](/api/datetime-format#datetime) at which to schedule a status. Providing this parameter will cause ScheduledStatus to be returned instead of Status. Must be at least 5 minutes in the future.
+
+quoted_status_id
+: String. ID of the status being quoted, if any. Will raise an error if the status does not exist, the author does not have access to it, or quoting is denied by Mastodon's understanding of the attached quote policy.
 
 #### Response
 ##### 200: OK

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -83,7 +83,7 @@ scheduled_at
 : String. [Datetime](/api/datetime-format#datetime) at which to schedule a status. Providing this parameter will cause ScheduledStatus to be returned instead of Status. Must be at least 5 minutes in the future.
 
 quoted_status_id
-: String. ID of the status being quoted, if any. Will raise an error if the status does not exist, the author does not have access to it, or quoting is denied by Mastodon's understanding of the attached quote policy.
+: String. ID of the status being quoted, if any. Will raise an error if the status does not exist, the author does not have access to it, or quoting is denied by Mastodon's understanding of the attached quote policy. All posts except Private Mentions (`direct` visibility) are quotable by their author. Quoting a `private` post will restrict the quoting post's `visibility` to `private` or `direct` (if the given `visibility` is `public` or `unlisted`, `private` will be used instead).
 
 quote_approval_policy
 : String (Enumerable, oneOf). Sets who is allowed to quote the status. Ignored if `visibility` is `private` or `direct`, in which case the policy will always be set to `nobody`.\

--- a/content/en/spec/activitypub.md
+++ b/content/en/spec/activitypub.md
@@ -856,13 +856,13 @@ Mastodon uses the `as:sensitive` extension property to mark certain posts as sen
 
 ### Quote posts and quote controls {#Quote}
 
-Mastodon implements experimental support for handling remote quote posts according to [FEP-044f](https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md). Additionally, it understands `quoteUri`, `quoteUrl` and `_misskey_quote` for compatibility.
+Mastodon implements support for handling remote quote posts according to [FEP-044f](https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md). Additionally, it understands `quoteUri`, `quoteUrl` and `_misskey_quote` for compatibility.
 
 Should a post contain multiple quotes, Mastodon only accepts the first one.
 
-Furthermore, Mastodon does not handle the full range of interaction policies, but instead converts the authorized followers to a combination of “public”, “followers” and “unknown”, defaulting to “nobody”.
+Furthermore, Mastodon does not handle the full range of interaction policies, but instead converts the authorized followers to a combination of “public”, “followers” and “nobody”, defaulting to “nobody”.
 
-At this time, Mastodon does not offer authoring quotes, nor does it expose a quote policy, or produce stamps for incoming quote requests.
+As of v4.5, Mastodon offers authoring quotes and granting quote approvals according to the same specification.
 
 ## Other functionality
 

--- a/content/en/spec/activitypub.md
+++ b/content/en/spec/activitypub.md
@@ -860,7 +860,7 @@ Mastodon implements support for handling remote quote posts according to [FEP-04
 
 Should a post contain multiple quotes, Mastodon only accepts the first one.
 
-Furthermore, Mastodon does not handle the full range of interaction policies, but instead converts the authorized followers to a combination of “public”, “followers” and “nobody”, defaulting to “nobody”.
+Furthermore, Mastodon does not handle the full range of interaction policies, but instead converts the authorized followers to a combination of “public”, “followers”, “following” and “nobody”, defaulting to “nobody”.
 
 As of v4.5, Mastodon offers authoring quotes and granting quote approvals according to the same specification.
 


### PR DESCRIPTION
While Mastodon 4.4 added support for verifying and displaying quote posts through a new `quote` attribute on [`Status`](https://docs.joinmastodon.org/entities/Status/#quote) and [`StatusEdit`](https://docs.joinmastodon.org/entities/StatusEdit/#quote) entities, Mastodon 4.5 adds support for viewing simplified *quote policies*, setting quote policies on outgoing posts, writing quote posts, getting quote notifications, listing quotes of one of your posts, revoking quotes, and being notified when a post you have quoted has been edited.

## API changes

The new APIs described below are available starting with [Mastodon API version](https://docs.joinmastodon.org/entities/Instance/#api_versionsmastodon) 7.

### New attributes to existing entities

- the [`Status`](https://docs.joinmastodon.org/entities/Status/) entity has a new `quote_approval` attribute, which holds a Hash with the following attributes:
  - `automatic`: list of strings, where each item is either `public`, `following`, `followers`, or `unsupported_policy`; an empty list means that no quote will be automatically accepted; `unsupported_policy` means the underlying policy is more complex than Mastodon understands
  - `manual`: list of strings, where each item is either `public`, `following`, `followers` or `unsupported_policy`; an empty list means that no quote will be manually accepted; `unsupported_policy` means the underlying policy is more complex than Mastodon understands
  - `current_user`: a single string, one of either `automatic`, `manual`, `denied` or `unknown`; `automatic` means any quote the user makes is expected to be automatically accepted, `manual` means any quote the user makes is expected to be manually review, `denied` means the user is not expected to be allowed to make quotes, and `unknown` means the underlying policy is too complex than Mastodon understands
- the [`Status`](https://docs.joinmastodon.org/entities/Status/) entity also has an additional `quotes_count` attribute counting the number of accepted quotes
- the [`CredentialAccount`](https://docs.joinmastodon.org/entities/Account/#CredentialAccount) entity has an additional `source[quote_policy]` attribute holding the default quote policy for the user. One of `public`, `followers` and `nobody`
- the response to `GET /api/v1/preferences` has a new attribute `posting:default:quote_policy` holding the default quote policy for the user. One of `public`, `followers` and `nobody`.

### New notification types

Mastodon 4.5 introduces two new notification types:
- `quote`: Someone quoted one of your posts. This means the quote post has been automatically accepted by Mastodon (Mastodon does not offer its user manual approval). The quote post is in the `status` attribute.
- `quoted_update`: A status you have quoted has been edited. This is similar to `update`, except `status` holds your quote post, not the post you have quoted. There is at this time no notification for a post quoting you being edited.

Those two notification types are also new `alerts` keys for requests to the `/api/v1/push` endpoint.

### New parameters to existing endpoints

The following endpoints have new parameters:
- `POST /api/v1/statuses` has two new optional parameters:
  - `quoted_status_id`: the identifier of the status to quote
    Tthis will raise an error if the current user does not have access to this status, or if Mastodon knows for sure the policy disallows it.
    Unless the quoted post is on the same server, the quote will be in [pending state](https://docs.joinmastodon.org/entities/Quote/#state) until it is explicitly accepted; quoting a private post is only possible in a private quote.
    Private Mentions cannot be quoted.
    A `<p class="quote-inline">RE: <a href="…">…</a></p>` link will be prepended to the body by the server for backward compatibility purposes if the body of the post does not already include a link to the quoted post. (This prepended paragraph will be hidden by the Mastodon Web UI)
  - `quote_approval_policy`: a string, one of `public`, `followers` or `nobody`; if omitted, it will use the user's default settings; if the status' visibility is `private` or `direct`, this parameter will be ignored and the policy be set to `nobody`
- `PUT /api/v1/statuses/:id` has one new parameter:
  - `quote_approval_policy`: a string, one of `public`, `followers` or `nobody`; if omitted, it will use the user's default settings; if the status' visibility is `private` or `direct`, this parameter will be ignored and the policy be set to `nobody`
- `PATCH /api/v1/accounts/update_credentials` has one new parameter:
  - `source[quote_policy]`: a string, one of `public`, `followers` or `nobody`, setting the default quote policy when making new posts

### New endpoints

- `GET /api/v1/statuses/:id/quotes`: returns a list of posts quoting the status specified by `id`; requires the current user to be the author of that status
- `POST /api/v1/statuses/:id/quotes/:quoting_status_id/revoke`: revoke quote authorization of post `quoting_status_id`, requires the status identified by `id` to be owned by the current user
- `PUT /api/v1/statuses/:id/interaction_policy`: use parameter `quote_approval_policy` to update the quote policy of a status without going through the entire edit flow

## General recommendations for clients

Generally speaking, a rough order of priorities for implementing quote-post related features should be the following:
- displaying quote posts, as not doing that may cause a loss of meaning when displaying posts that are intended to be quotes
- handling quote notifications and offering to revoke quotes, as users who did not change the default posting setting will be quotable
- handling changing the quote policy of new and existing posts
- handling authoring of quote posts

### Displaying quote posts

Displaying quote posts should be fairly straightforward, given the [`Quote`](https://docs.joinmastodon.org/entities/Quote) and [`ShallowQuote`](https://docs.joinmastodon.org/entities/ShallowQuote/) entities already contain all the pre-processed information.

Don't forget to apply filters to quoted posts as well. In this regard, the context type is inherited from the quoting post (i.e. if it's in a home timeline, the filter for home timelines should apply), and we have decided for the Mastodon Web UI to still show the quoting post if the quoted post matches a `hide` action filter but not the quoting post. In this case, the Mastodon Web UI hides the quoted post with “Hidden due to one of your filters”.

We do not recommend displaying quotes more than 1 level deep, and recommend having a placeholder instead:
<img width="383" height="412" alt="image" src="https://github.com/user-attachments/assets/5dc484b9-cb5c-4ac4-b653-6f238d35dc13" />
If you do decide to handle deeper quotes, be mindful of potential infinite recursion.

Additionally, if a status has a `quote`, you should remove/hide from its contents any element with the `quote-inline` CSS class, as this will be used for fallback and will otherwise be redundant.

### Interpreting quote policies

While Mastodon currently only allows setting very straightforward quote policies (only automatic approval, `public`, `followers` or `nobody`), the underlying protocol allows for both automatic approval and manual approval policies, and allows each of these policies to list arbitrary accounts. Mastodon has chosen to support only a subset of that for implementation complexity and database storage reasons, but will still expose policies with more granularity than it allows setting.

In particular, it supports the split between automatic and manual policies, and will also record when one of these sub-policies is too complex to be accurately represented by Mastodon. This will be represented as an `unsupported_policy` value in the sub-policy.

Through the `current_user` attribute discussed above, Mastodon will tell API consumers if they are `denied` the ability to quote a post, if the approval will be `automatic`, if the quote approval will be `manual`, or if it is `unknown` to Mastodon. That last case should probably be treated as `denied`, unless you target “power users” who want the most accurate representation possible and be able to author a quote even if it will be likely rejected.

The `automatic` and `manual` lists can be used to convey the policy as accurately possible to users.

For reference, the Mastodon Web UI uses the `current_user`, `automatic` and `manual` values as follow:
- if `current_user` is `automatic`, allow quoting the post and label the button “Quote”
- if the `current_user` is `manual`, allow quoting the post and label the button “Request to quote” / “Author will manually review”
- if the `current_user` is `unknown` or `denied`, disallow quoting, and display either “Only followers can quote this post” or “You are not allowed to quote this post” depending on the presence of `followers` in the policies

### Setting quote policies

As discussed above, while the underlying protocol allows for more complex policies, Mastodon only supports setting a few predefined policies:
- `public` (“Anybody can quote”): anybody except blocked users will be able to quote
- `followers` (“Only followers can quote”): only followers and the author will be able to quote
- `nobody` (“Just me”): only the author will be able to quote

The author is always allowed to quote themselves (except for private mentions), and blocked users are never allowed to quote (Mastodon will automatically reject their quotes). Approval is automatically handled by Mastodon, meaning there is no manual authorization for clients (but there is a posteriori removal of quotes).

Mastodon will always set the policy of `private` (“followers-only”) and `direct` (“private mentions”) posts to `nobody` (“Just me”), but the UI should be mindful of these limits to avoid user confusion.

### Authoring quote posts

Mastodon 4.5 lets people quote posts if the policy allows it. It doesn't allow adding a poll or media attachment together with a quote, so clients should be mindful of that. Editing a post can't remove or change a quote.