### PR TITLE
Clarify 'Account#roles' attribute nullability

### DIFF
--- a/content/en/entities/Account.md
+++ b/content/en/entities/Account.md
@@ -305,8 +305,8 @@ aliases: [
 
 ### `roles` {#roles}
 
-**Description:** An array of roles assigned to the user that are publicly visible (highlighted roles only), if the account is local. Will be an empty array if no roles are highlighted or if the account is remote.\
-**Type:** Array of [AccountRole](#AccountRole)\
+**Description:** An array of roles assigned to the user that are publicly visible (highlighted roles only), if the account is local. Will be an empty array if no roles are highlighted or null if the account is remote.\
+**Type:** {{<nullable>}} Array of [AccountRole](#AccountRole)\
 **Version history:**\
 4.1.0 - added
 


### PR DESCRIPTION
- local response has `roles: []` https://mastodon.social/api/v1/accounts/lookup?acct=mastodon
- remote response has null https://indieweb.social/api/v1/accounts/lookup?acct=mastodon@mastodon.social