### PR TITLE
Fix limit description for "See quotes of a status"

### DIFF
--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -852,7 +852,7 @@ since_id
 : **Internal parameter.** Use HTTP `Link` header for pagination.
 
 limit
-: Integer. Maximum number of results to return. Defaults to 40 accounts. Max 80 accounts.
+: Integer. Maximum number of results to return. Defaults to 20 statuses. Max 40 statuses.
 
 #### Response
 ##### 200: OK


### PR DESCRIPTION
Fix s/accounts/statuses.

I also suspect that DEFAULT_STATUSES_LIMIT applies here too, so instead of default 40, should be 20. I didn't test/check this so I'll update this PR if it's wrong 🙇‍♂️