### PR TITLE
Add ProcessingMediaAttachment for async media upload

### DIFF
--- a/content/en/entities/MediaAttachment.md
+++ b/content/en/entities/MediaAttachment.md
@@ -245,6 +245,15 @@ May contain subtrees `small` and `original`, as well as various other top-level 
 0.6.0 - added\
 3.5.0 - removed
 
+## ProcessingMediaAttachment entity attributes {#ProcessingMediaAttachment}
+
+A MediaAttachment that is currently being processed.
+
+### `url` {#url}
+
+**Description:** The location of the original full-size attachment.\
+**Type:** {{<nullable>}} String (URL)
+
 ## See also
 
 {{< page-relref ref="entities/Status#media_attachments" caption="Status (`media_attachments` attribute)" >}}

--- a/content/en/methods/media.md
+++ b/content/en/methods/media.md
@@ -28,7 +28,7 @@ POST /api/v2/media HTTP/1.1
 
 Creates a media attachment to be used with a new status. The full sized media will be processed asynchronously in the background for large uploads.
 
-**Returns:** [MediaAttachment]({{< relref "entities/MediaAttachment" >}}), but without a URL\
+**Returns:** [MediaAttachment]({{< relref "entities/MediaAttachment" >}}) with a HTTP 200 response or [ProcessingMediaAttachment]({{< relref "entities/MediaAttachment#ProcessingMediaAttachment" >}}) with a HTTP 202 response\
 **OAuth:** User token + `write:media`\
 **Version history:**\
 3.1.3 - added\
@@ -94,7 +94,7 @@ MediaAttachment was created successfully, and the full-size file was processed s
 
 ##### 202: Accepted
 
-MediaAttachment was created successfully, but the full-size file is still processing. Note that the MediaAttachment's `url` will still be null, as the media is still being processed in the background. However, the `preview_url` should be available. Use [`GET /api/v1/media/:id`](#get) to check the status of the media attachment.
+ProcessingMediaAttachment was created successfully, but the full-size file is still processing. Note that the ProcessingMediaAttachment's `url` will still be null, as the media is still being processed in the background. However, the `preview_url` should be available. Use [`GET /api/v1/media/:id`](#get) to check the status of the media attachment.
 
 ```json
 {


### PR DESCRIPTION
Add `ProcessingMediaAttachment` to indicate a HTTP 202 response is still processing.