### PR TITLE
Change type of most_recent_notification_id to Integer

### DIFF
--- a/content/en/methods/grouped_notifications.md
+++ b/content/en/methods/grouped_notifications.md
@@ -600,7 +600,7 @@ TODO
 #### `most_recent_notification_id`
 
 **Description:** ID of the most recent notification in the group.\
-**Type:** String\
+**Type:** Integer\
 **Version history:**\
 4.3.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 2) - added
 


### PR DESCRIPTION
API responses I'm seeing and the examples in the docs are integers.