### PR TITLE
Update fetch preview card endpoint to removed

### DIFF
--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -2226,7 +2226,7 @@ Status does not exist or is private.
 
 ---
 
-## Fetch preview card {{%deprecated%}} {#card}
+## Fetch preview card {{%removed%}} {#card}
 
 ```http
 GET /api/v1/statuses/:id/card HTTP/1.1


### PR DESCRIPTION
Version history lists it as removed but the endpoint was still listed as deprecated.