### PR TITLE
Mark MediaAttachment#url as nullable

### DIFF
--- a/content/en/entities/MediaAttachment.md
+++ b/content/en/entities/MediaAttachment.md
@@ -178,8 +178,8 @@ aliases: [
 
 ### `url` {#url}
 
-**Description:** The location of the original full-size attachment.\
-**Type:** String (URL)\
+**Description:** The location of the original full-size attachment. Url may be null if the file is still being processed. See [`POST /api/v2/media`]({{< relref "methods/media" >}}#v2).\
+**Type:** {{<nullable>}} String (URL)\
 **Version history:**\
 0.6.0 - added
 


### PR DESCRIPTION
If the media attachment is a large file it might still be processing in the background.