### PR TITLE
Fix Instance enum formatting

### DIFF
--- a/content/en/entities/Instance.md
+++ b/content/en/entities/Instance.md
@@ -772,9 +772,9 @@ aliases: [
 
 **Description:** Access restrictions for local posts in the public “firehose” feed.\
 **Type:** String (Enumerable oneOf)\
-- `public` = Access to local posts in the public “firehose” feed is available to both visitors and logged-in users.\
-- `authenticated` = Access to local posts in the public “firehose” feed requires authentication.\
-- `disabled` = Access to local posts in the public “firehose” feed is only possible for users with the “View live and topic feeds” [permission]({{< relref "entities/Role#permissions" >}}).\
+`public` = Access to local posts in the public “firehose” feed is available to both visitors and logged-in users.\
+`authenticated` = Access to local posts in the public “firehose” feed requires authentication.\
+`disabled` = Access to local posts in the public “firehose” feed is only possible for users with the “View live and topic feeds” [permission]({{< relref "entities/Role#permissions" >}}).\
 **Version history:**\
 4.5.0 - added
 
@@ -782,9 +782,9 @@ aliases: [
 
 **Description:** Access restrictions for remote posts in the public “firehose” feed.\
 **Type:** String (Enumerable oneOf)\
-- `public` = Access to remote posts in the public “firehose” feed is available to both visitors and logged-in users.\
-- `authenticated` = Access to remote posts in the public “firehose” feed requires authentication.\
-- `disabled` = Access to remote posts in the public “firehose” feed is only possible for users with the “View live and topic feeds” [permission]({{< relref "entities/Role#permissions" >}}).\
+`public` = Access to remote posts in the public “firehose” feed is available to both visitors and logged-in users.\
+`authenticated` = Access to remote posts in the public “firehose” feed requires authentication.\
+`disabled` = Access to remote posts in the public “firehose” feed is only possible for users with the “View live and topic feeds” [permission]({{< relref "entities/Role#permissions" >}}).\
 **Version history:**\
 4.5.0 - added
 
@@ -799,9 +799,9 @@ aliases: [
 
 **Description:** Access restrictions for local posts in hashtag feeds.\
 **Type:** String (Enumerable oneOf)\
-- `public` = Access to local posts in hashtag feeds is available to both visitors and logged-in users.\
-- `authenticated` = Access to local posts in hashtag feeds requires authentication.\
-- `disabled` = Access to local posts in hashtag feeds is only possible for users with the “View live and topic feeds” [permission]({{< relref "entities/Role#permissions" >}}).\
+`public` = Access to local posts in hashtag feeds is available to both visitors and logged-in users.\
+`authenticated` = Access to local posts in hashtag feeds requires authentication.\
+`disabled` = Access to local posts in hashtag feeds is only possible for users with the “View live and topic feeds” [permission]({{< relref "entities/Role#permissions" >}}).\
 **Version history:**\
 4.5.0 - added
 
@@ -809,9 +809,9 @@ aliases: [
 
 **Description:** Access restrictions for remote posts in hashtag feeds.\
 **Type:** String (Enumerable oneOf)\
-- `public` = Access to remote posts in hashtag feeds is available to both visitors and logged-in users.\
-- `authenticated` = Access to remote posts in hashtag feeds requires authentication.\
-- `disabled` = Access to remote posts in hashtag feeds is only possible for users with the “View live and topic feeds” [permission]({{< relref "entities/Role#permissions" >}}).\
+`public` = Access to remote posts in hashtag feeds is available to both visitors and logged-in users.\
+`authenticated` = Access to remote posts in hashtag feeds requires authentication.\
+`disabled` = Access to remote posts in hashtag feeds is only possible for users with the “View live and topic feeds” [permission]({{< relref "entities/Role#permissions" >}}).\
 **Version history:**\
 4.5.0 - added
 
@@ -826,9 +826,9 @@ aliases: [
 
 **Description:** Access restrictions for local posts in the trending link feeds.\
 **Type:** String (Enumerable oneOf)\
-- `public` = Access to local posts in trending link feeds is available to both visitors and logged-in users.\
-- `authenticated` = Access to local posts in trending link feeds requires authentication.\
-- `disabled` = Access to local posts in trending link feeds is only possible for users with the “View live and topic feeds” [permission]({{< relref "entities/Role#permissions" >}}).\
+`public` = Access to local posts in trending link feeds is available to both visitors and logged-in users.\
+`authenticated` = Access to local posts in trending link feeds requires authentication.\
+`disabled` = Access to local posts in trending link feeds is only possible for users with the “View live and topic feeds” [permission]({{< relref "entities/Role#permissions" >}}).\
 **Version history:**\
 4.5.0 - added
 
@@ -836,9 +836,9 @@ aliases: [
 
 **Description:** Access restrictions for remote posts in trending link feeds.\
 **Type:** String (Enumerable oneOf)\
-- `public` = Access to remote posts in trending link feeds is available to both visitors and logged-in users.\
-- `authenticated` = Access to remote posts in trending link feeds requires authentication.\
-- `disabled` = Access to remote posts in trending link feeds is only possible for users with the “View live and topic feeds” [permission]({{< relref "entities/Role#permissions" >}}).\
+`public` = Access to remote posts in trending link feeds is available to both visitors and logged-in users.\
+`authenticated` = Access to remote posts in trending link feeds requires authentication.\
+`disabled` = Access to remote posts in trending link feeds is only possible for users with the “View live and topic feeds” [permission]({{< relref "entities/Role#permissions" >}}).\
 **Version history:**\
 4.5.0 - added
 


### PR DESCRIPTION
Update [Instance attribute enums ](https://docs.joinmastodon.org/entities/Instance/#timeline_access-live_feeds-local)formatting that renders poorly (note the visible `/` at the end of lines) 
<img width="835" height="408" alt="Screenshot 2025-10-29 at 20 20 12" src="https://github.com/user-attachments/assets/f2cdec8b-db0b-4027-be53-e8ba33eeaddb" />

to match how [other enums](https://docs.joinmastodon.org/entities/AccountWarning/#action) are formatted.
<img width="839" height="420" alt="Screenshot 2025-10-29 at 20 19 56" src="https://github.com/user-attachments/assets/78151f44-cdde-4b46-9a44-e2fa8e8bd41e" />
