### PR TITLE
Better describe what `accounts cull` does when domain is not available

### DIFF
--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -192,7 +192,7 @@ Request a backup for a user account with the given USERNAME. The backup will be 
 
 ### `tootctl accounts cull` {#accounts-cull}
 
-Remove remote accounts that no longer exist. Queries every single remote account in the database to determine if it still exists on the origin server, and if it doesn't, then remove it from the database. Accounts that have had confirmed activity within the last week are excluded from the checks, in case the server is just down.
+Remove remote accounts that no longer exist. Queries every single remote account in the database to determine if it still exists on the origin server, and if it doesn't, then remove it from the database. Accounts that have had confirmed activity within the last week are excluded from the checks. If the account's domain is not accessible during the check, the account is not culled and the domain is reported at the end of the script.
 
 `DOMAIN[...]`
 : Optionally pass specific domains to cull


### PR DESCRIPTION
Me - and apparently other people - were confused about the expected behavior of `accounts cull` when the accounts domain is unavailable (the issue  https://github.com/mastodon/mastodon/issues/32276 was filed because of this misunderstanding). 

I've clarified the docs to match what happens in the code (https://github.com/mastodon/mastodon/blob/d865a095d0e77ae91091591790eb3c4e9759e1c2/lib/mastodon/cli/accounts.rb#L303) (as well as the `long_desc` in the code)