### PR TITLE
Update asset references for Vite

### DIFF
--- a/content/en/admin/troubleshooting.md
+++ b/content/en/admin/troubleshooting.md
@@ -34,7 +34,7 @@ The `debug` or `silly` levels can be very verbose and you should take care to ch
 
 ## **After an upgrade to a newer version, some pages look weird, like they have unstyled elements. Why?**
 
-Check that you have run `RAILS_ENV=production bin/rails assets:precompile` after the upgrade, and restarted Mastodon’s web process, because it looks like it’s serving outdated stylesheets and scripts. It’s also possible that the precompilation fails due to a lack of RAM, as webpack is unfortunately extremely memory-hungry. If that is the case, make sure you have some swap space assigned. Alternatively, it’s possible to precompile the assets on a different machine, then copy over the `public/packs` directory.
+Check that you have run `RAILS_ENV=production bin/rails assets:precompile` after the upgrade, and restarted Mastodon’s web process, because it looks like it’s serving outdated stylesheets and scripts. If precompilation fails, it’s possible to precompile the assets on a different machine, then copy over the `public/packs` directory.
 
 ## **After an upgrade to a newer version, some requests fail and the logs show error messages about missing columns or tables. Why?**
 

--- a/content/en/dev/overview.md
+++ b/content/en/dev/overview.md
@@ -25,7 +25,7 @@ The default value of `RAILS_ENV` is `development`, so you don’t need to set an
 
 - Ruby code reloads itself when you change it, which means you don’t need to restart the Rails server process to see changes
 - All errors you encounter show stack traces in the browser, rather than being hidden behind a generic error page
-- Webpack runs continuously and re-compiles JS and CSS assets when you change any of the front-end files, and the pages automatically reload
+- Vite runs continuously and re-compiles JS and CSS assets when you change any of the front-end files, and the pages automatically reload
 - Caching is disabled by default
 - An admin account with the e-mail `admin@localhost:3000` and password `mastodonadmin` is created automatically during `db:seed`
 

--- a/content/en/dev/setup.md
+++ b/content/en/dev/setup.md
@@ -80,7 +80,7 @@ gem install foreman --no-document
 foreman start
 ```
 
-This will start processes defined in `Procfile.dev`, which will give you: A Rails server, a Webpack server, a streaming API server, and Sidekiq. Of course, you can run any of those things stand-alone depending on your needs.
+This will start processes defined in `Procfile.dev`, which will give you: a Rails web server, a Vite server for assets, a streaming API server, and Sidekiq for background jobs. Of course, you can run any of those things stand-alone depending on your needs.
 
 ## Working with emails in development
 


### PR DESCRIPTION
There's one remaining webpack reference in the `zh-cn` translation that I'm not sure how/if to update.