### PR TITLE
Rely on default bundle jobs count during install

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -137,7 +137,7 @@ Now to install Ruby and JavaScript dependencies:
 ```bash
 bundle config deployment 'true'
 bundle config without 'development test'
-bundle install -j$(getconf _NPROCESSORS_ONLN)
+bundle install
 yarn install
 ```
 


### PR DESCRIPTION
At some point in the 2.2.x series this changed to be the default (or perhaps platform-depending, but more or less...)