### PR TITLE
Fix typo in docs

### DIFF
--- a/content/en/admin/backups.md
+++ b/content/en/admin/backups.md
@@ -7,7 +7,7 @@ menu:
     parent: admin
 ---
 
-For any real-world use, you should make sure to regularly backup your Mastodon server.
+For any real-world use, you should make sure to regularly back up your Mastodon server.
 
 ## Overview {#overview}
 

--- a/content/en/admin/migrating.md
+++ b/content/en/admin/migrating.md
@@ -44,7 +44,7 @@ At a high level, you’ll need to copy over the following:
 * The `~/live/public/system` directory, which contains user-uploaded images and videos (if using S3, you don’t need this)
 * The PostgreSQL database (using [pg_dump](https://www.postgresql.org/docs/9.1/static/backup-dump.html))
 * The `~/live/.env.production` file, which contains server config and secrets
-* The Redis database in the `/var/lib/redis/` directory, which contains unproccessed Sidekiq jobs.
+* The Redis database in the `/var/lib/redis/` directory, which contains unprocessed Sidekiq jobs.
 
 Less crucially, you’ll probably also want to copy the following for convenience:
 

--- a/content/en/admin/optional/captcha.md
+++ b/content/en/admin/optional/captcha.md
@@ -27,6 +27,6 @@ Other providers may be added in the future.
 - From the Account Settings menu in hCaptcha, obtain your Secret Key
 - Add the values to your Mastodon environment configuration as `HCAPTCHA_SITE_KEY` and `HCAPTCHA_SECRET_KEY`
 - Restart the Mastodon services running on your server
-- From the Mastodon web interface navigate to **Administration**  > **Server settings** > **Registrations** and check the box labled "Require new users to solve a CAPTCHA to confirm their account"
+- From the Mastodon web interface navigate to **Administration**  > **Server settings** > **Registrations** and check the box labeled "Require new users to solve a CAPTCHA to confirm their account"
 
 ![](/assets/captcha/admin-view.png)

--- a/content/en/admin/optional/object-storage.md
+++ b/content/en/admin/optional/object-storage.md
@@ -211,7 +211,7 @@ limits.
 
 Default: 3
 
-During batch delete operations, S3 providers may perodically fail or
+During batch delete operations, S3 providers may periodically fail or
 timeout while processing deletion requests. Mastodon will back off and
 retry the request up to this maximum number of times.
 

--- a/content/en/admin/optional/tor.md
+++ b/content/en/admin/optional/tor.md
@@ -175,7 +175,7 @@ When this happens you may uncomment the following line in your nginx.conf:
 # server_names_hash_bucket_size 64;
 ```
 
-If you still have problems you may consider incresing the size up to 128. 
+If you still have problems you may consider increasing the size up to 128. 
 
 ## Gotchas {#gotchas}
 

--- a/content/en/admin/scaling.md
+++ b/content/en/admin/scaling.md
@@ -418,7 +418,7 @@ REPLICA_DB_TASKS
 
 Alternatively, you can also use `REPLICA_DATABASE_URL` if you want to configure them all using the same variable.
 
-`REPLICA_DB_TASKS=false` will connect to an replica database without any database mangement tasks such as schema management, migrations, seeds, etc. By default it is set to true.
+`REPLICA_DB_TASKS=false` will connect to an replica database without any database management tasks such as schema management, migrations, seeds, etc. By default it is set to true.
 
 `REPLICA_PREPARED_STATEMENTS` is an optional override for the `PREPARED_STATEMENTS` value. By default it is set to true if `PREPARED_STATEMENTS` is not set.
 

--- a/content/en/client/authorized.md
+++ b/content/en/client/authorized.md
@@ -13,7 +13,7 @@ When we register our app and when we authorize our user, we need to define what 
 
 When authorizing a user, the `scope` query parameter must be a subset of those we specified when we created our app. In our ongoing example, we specified `read write push` as our scopes when we created our app, however it is a better idea to only request access to what your app will actually need through [granular scopes]({{< relref "api/oauth-scopes#granular-scopes" >}}).
 
-See [OAuth Scopes]({{< relref "api/oauth-scopes" >}}) for a full list of scopes. Each API method's documentation will also specify the OAuth [token type]({{< relref "api/oauth-tokens" >}}) and the scopes required to call it. If an endpoint specifies `read:statuses` and you have `read` access, then you will be able to use that endpoint, since scopes are hierarchial.
+See [OAuth Scopes]({{< relref "api/oauth-scopes" >}}) for a full list of scopes. Each API method's documentation will also specify the OAuth [token type]({{< relref "api/oauth-tokens" >}}) and the scopes required to call it. If an endpoint specifies `read:statuses` and you have `read` access, then you will be able to use that endpoint, since scopes are hierarchical.
 
 {{< page-relref ref="api/oauth-scopes" caption="OAuth Scopes" >}}
 

--- a/content/en/entities/Error.md
+++ b/content/en/entities/Error.md
@@ -77,7 +77,7 @@ Error: Your login is currently pending approval. Appears when the OAuth token's 
 
 #### RecordNotFound {#not-found}
 
-Error: Record not found. Appears when an entity record does not exist, or the authorized user is not within the audience of a private entity.operates on a user.
+Error: Record not found. Appears when an entity record does not exist, or the authorized user is not within the audience of a private entity.
 
 ### 422 - Unprocessable entity {#422}
 

--- a/content/en/entities/Role.md
+++ b/content/en/entities/Role.md
@@ -126,7 +126,7 @@ To determine the permissions available to a certain role, convert the `permissio
 : **Delete User Data**. Allows users to delete other users' data without delay.
 
 0x100000
-: **View live and topic feeds**. Allows users to view publice “firehose”, hashtag and link feeds even when those are disabled.
+: **View live and topic feeds**. Allows users to view public “firehose”, hashtag and link feeds even when those are disabled.
 
 ## See also
 

--- a/content/en/entities/ShallowQuote.md
+++ b/content/en/entities/ShallowQuote.md
@@ -32,7 +32,7 @@ aliases: [
 `unauthorized` = The quote has been approved, but cannot be displayed because the user is not authorized to see it.\
 `blocked_account` = The quote has been approved, but should not be displayed because the user has blocked the account being quoted. This is one of the few cases where `quoted_status_id` is non-null.\
 `blocked_domain` = The quote has been approved, but should not be displayed because the user has blocked the domain of the account being quoted. This is one of the few cases where `quoted_status_id` is non-null.\
-`muted_account` = The quote has been approved, but should not be displayed because the user has muted the the account being quoted. This is one of the few cases where `quoted_status_id` is non-null.
+`muted_account` = The quote has been approved, but should not be displayed because the user has muted the account being quoted. This is one of the few cases where `quoted_status_id` is non-null.
 **Version history:**\
 4.4.0 - added\
 4.5.0 - added `blocked_account`, `blocked_domain` and `muted_account`

--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -1124,15 +1124,16 @@ Sample output with limit=2.
     "id": "963410",
     "username": "gautambhatia",
     "acct": "gautambhatia",
-    "display_name": "Gautam Bhatia",
+    "display_name": "Gautam Bhatia"
     // ...
   },
   {
     "id": "1007400",
     "username": "seafrog",
     "acct": "seafrog@glitterkitten.co.uk",
-    "display_name": "🐓🦃 Heck Partridge 🤠 🦆",
+    "display_name": "🐓🦃 Heck Partridge 🤠 🦆"
     // ...
+  }
 ]
 ```
 

--- a/content/en/methods/admin/domain_blocks.md
+++ b/content/en/methods/admin/domain_blocks.md
@@ -244,7 +244,7 @@ The domain parameter already is covered by an existing domain block.
 
 ```json
 {
-  "error": "You have already imposed stricter limits on example.com."
+  "error": "You have already imposed stricter limits on example.com.",
   "existing_domain_block": {
     "id": "1",
     "domain": "example.com",

--- a/content/en/methods/async_refreshes.md
+++ b/content/en/methods/async_refreshes.md
@@ -48,7 +48,7 @@ The `status` of an async refresh is either `running` or `finished`. For some asy
 
 Please note that the asynchronous nature of background jobs can lead to race conditions. Also the fact that some async refreshes might be user-agnostic while the fetched data is not, might mean that while new data is fetched, it will not be suitable for the current user. For example a background could be triggered to fetch new replies to a post. New replies could exist but the current usr might have blocked their authors.
 
-For those reasons the `AsyncRefresh` can only ever serve as an indicator of when it could be worthwile for a client to request new data. In the general case there is no guarantee that new data will be served.
+For those reasons the `AsyncRefresh` can only ever serve as an indicator of when it could be worthwhile for a client to request new data. In the general case there is no guarantee that new data will be served.
 
 **Returns:** [AsyncRefresh]({{< relref "entities/AsyncRefresh" >}})\
 **OAuth:** App token + `read`\

--- a/content/en/methods/grouped_notifications.md
+++ b/content/en/methods/grouped_notifications.md
@@ -31,7 +31,7 @@ GET /api/v2/notifications HTTP/1.1
 
 Return grouped notifications concerning the user. This API returns Link headers containing links to the next/previous page. However, the links can also be constructed dynamically using query params and `id` values.
 
-Notifications of type `favourite`, `follow`, `reblog` or `admin.sign_up` with the same type and the same target made in a similar timeframe are given a same `group_key` by the server, and querying this endpoint will return aggregated notifications, with only one object per `group_key`. Other notification types may be grouped in the future. The `grouped_types` parameter should be used by the client to explictely list the types it supports showing grouped notifications for.
+Notifications of type `favourite`, `follow`, `reblog` or `admin.sign_up` with the same type and the same target made in a similar timeframe are given a same `group_key` by the server, and querying this endpoint will return aggregated notifications, with only one object per `group_key`. Other notification types may be grouped in the future. The `grouped_types` parameter should be used by the client to explicitly list the types it supports showing grouped notifications for.
 
 Types to filter include:
 - `mention` = Someone mentioned you in their status
@@ -403,7 +403,7 @@ GET /api/v2/notifications/unread_count HTTP/1.1
 
 Get the (capped) number of unread notification groups for the current user.
 A notification is considered unread if it is more recent than the [notifications read marker]({{< relref "methods/markers" >}}).
-Because the count is dependant on the parameters, it is computed every time and is thus a relatively slow operation (although faster than getting the full corresponding notifications), therefore the number of returned notifications is capped.
+Because the count is dependent on the parameters, it is computed every time and is thus a relatively slow operation (although faster than getting the full corresponding notifications), therefore the number of returned notifications is capped.
 
 **Returns:** Hash with a single key of `count`\
 **OAuth:** User token + `read:notifications`\

--- a/content/en/methods/notifications.md
+++ b/content/en/methods/notifications.md
@@ -403,7 +403,7 @@ GET /api/v1/notifications/unread_count HTTP/1.1
 
 Get the (capped) number of unread notifications for the current user.
 A notification is considered unread if it is more recent than the [notifications read marker]({{< relref "methods/markers" >}}).
-Because the count is dependant on the parameters, it is computed every time and is thus a relatively slow operation (although faster than getting the full corresponding notifications), therefore the number of returned notifications is capped.
+Because the count is dependent on the parameters, it is computed every time and is thus a relatively slow operation (although faster than getting the full corresponding notifications), therefore the number of returned notifications is capped.
 
 **Returns:** Hash with a single key of `count`\
 **OAuth:** User token + `read:notifications`\

--- a/content/en/methods/notifications_alpha.md
+++ b/content/en/methods/notifications_alpha.md
@@ -340,7 +340,7 @@ GET /api/v2_alpha/notifications/unread_count HTTP/1.1
 
 Get the (capped) number of unread notification groups for the current user.
 A notification is considered unread if it is more recent than the [notifications read marker]({{< relref "methods/markers" >}}).
-Because the count is dependant on the parameters, it is computed every time and is thus a relatively slow operation (although faster than getting the full corresponding notifications), therefore the number of returned notifications is capped.
+Because the count is dependent on the parameters, it is computed every time and is thus a relatively slow operation (although faster than getting the full corresponding notifications), therefore the number of returned notifications is capped.
 
 **Returns:** Hash with a single key of `count`\
 **OAuth:** User token + `read:notifications`\
@@ -419,7 +419,7 @@ Invalid or missing Authorization header.
 #### `statuses`
 
 **Description:** Statuses referenced by grouped notifications.\
-**Type:** Array of [Status]({{< relref "entities/Status" >}}}\
+**Type:** Array of [Status]({{< relref "entities/Status" >}})\
 **Version history:**\
 4.3.0-beta.1 - added\
 4.3.0-beta.2 - deprecated

--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -47,7 +47,7 @@ scope
 : String. List of requested [OAuth scopes]({{< relref "api/oauth-scopes" >}}), separated by spaces (or by pluses, if using query parameters). Must be a subset of `scopes` declared during app registration. If not provided, defaults to `read`.
 
 state
-: String. Arbitrary value to passthrough to your server when the user authorizes or rejects the authorization request.
+: String. Arbitrary value to pass through to your server when the user authorizes or rejects the authorization request.
 
 code_challenge
 : String. The [PKCE code challenge]({{< relref "spec/oauth#pkce" >}}) for the authorization request.
@@ -391,7 +391,7 @@ On Mastodon versions before 4.3.0, requesting this endpoint will result in a `40
 
 Instead, you will need to "guess" what that server supports, instead of discovering supported OAuth 2 endpoints, grant flows & scopes dynamically.
 
-You may want to fallback to the [Instance Metadata endpoint]({{< relref "methods/instance#v2" >}}) to try to discover what Mastodon version the server is running by parsing the `version` field; however, this is very brittle and not recommended.
+You may want to fall back to the [Instance Metadata endpoint]({{< relref "methods/instance#v2" >}}) to try to discover what Mastodon version the server is running by parsing the `version` field; however, this is very brittle and not recommended.
 
 ---
 

--- a/content/en/methods/search.md
+++ b/content/en/methods/search.md
@@ -85,14 +85,14 @@ Truncated results of a sample search for "cats" with limit=2.
       "id": "180744",
       "username": "catstar",
       "acct": "catstar@catgram.jp",
-      "display_name": "catstar",
+      "display_name": "catstar"
       // ...
     },
     {
       "id": "214293",
       "username": "catsareweird",
       "acct": "catsareweird",
-      "display_name": "Cats Are Weird",
+      "display_name": "Cats Are Weird"
       // ...
     }
   ],
@@ -101,7 +101,7 @@ Truncated results of a sample search for "cats" with limit=2.
       "id": "103085519055545958",
       "created_at": "2019-11-05T13:23:09.000Z",
       // ...
-      "content": "<p>cats<br>cats never change</p>",
+      "content": "<p>cats<br>cats never change</p>"
       // ...
     },
     {
@@ -110,8 +110,9 @@ Truncated results of a sample search for "cats" with limit=2.
       // ...
       "spoiler_text": "Cats",
       // ...
-      "content": "<p>Cats are inherently good at self-care. </p><p><a href=\"https://mspsocial.net/tags/cats\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>cats</span></a></p>",
+      "content": "<p>Cats are inherently good at self-care. </p><p><a href=\"https://mspsocial.net/tags/cats\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>cats</span></a></p>"
       // ...
+    }
   ],
   "hashtags": [
     {
@@ -123,7 +124,7 @@ Truncated results of a sample search for "cats" with limit=2.
           "day": "1574553600",
           "uses": "10",
           "accounts": "9"
-        },
+        }
         // ...
       ]
     },
@@ -136,7 +137,7 @@ Truncated results of a sample search for "cats" with limit=2.
           "day": "1574553600",
           "uses": "6",
           "accounts": "5"
-        },
+        }
         // ...
       ]
     }

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -410,7 +410,7 @@ Authorization
 #### Response
 ##### 200: OK
 
-Note the special properties `text` and `poll` or `media_attachments` which may be used to repost the status, e.g. in case of delete-and-redraft functionality. With [POST /api/v1/statuses](#create), use `text` as the value for `status` parameter, `media_attachments[n]["id"]` for the `media_ids` array parameter, and `poll` properties with the corresponding parameters (e.g. `poll[multiple]` and `poll[options]`, with a new `poll[expires_in]` and `poll[hide_totals]` per user input.
+Note the special properties `text` and `poll` or `media_attachments` which may be used to repost the status, e.g. in case of delete-and-redraft functionality. With [POST /api/v1/statuses](#create), use `text` as the value for `status` parameter, `media_attachments[n]["id"]` for the `media_ids` array parameter, and `poll` properties with the corresponding parameters (e.g. `poll[multiple]` and `poll[options]`), with a new `poll[expires_in]` and `poll[hide_totals]` per user input.
 
 Example of deleting a media post:
 

--- a/content/en/methods/suggestions.md
+++ b/content/en/methods/suggestions.md
@@ -54,8 +54,9 @@ limit
     "account": {
       "id": "784058",
       "username": "katie",
-      "acct": "katie@pleroma.voidlurker.net",
+      "acct": "katie@pleroma.voidlurker.net"
       // ...
+    }
   },
   // ...
   {
@@ -63,8 +64,9 @@ limit
     "account": {
       "id": "108194863260762493",
       "username": "thunderbird",
-      "acct": "thunderbird@mastodon.online",
+      "acct": "thunderbird@mastodon.online"
       // ...
+    }
   }
 ]
 ```

--- a/content/en/spec/activitypub.md
+++ b/content/en/spec/activitypub.md
@@ -140,7 +140,7 @@ attributedTo
 : Used to determine the profile which authored the status
 
 to/cc
-: Used to determine audience and visibility of a status, in combination with mentions. See [Mentions for adddressing and notifications](#Mention)
+: Used to determine audience and visibility of a status, in combination with mentions. See [Mentions for addressing and notifications](#Mention)
 
 tag
 : Used to mark up mentions and hashtags.

--- a/content/en/spec/webfinger.md
+++ b/content/en/spec/webfinger.md
@@ -19,7 +19,7 @@ Enter WebFinger. WebFinger as described in [RFC 7033](https://tools.ietf.org/htm
 
 ## Sample WebFinger flow {#example}
 
-Suppose we want to lookup the user `@Gargron` hosted on the `mastodon.social` website.
+Suppose we want to look up the user `@Gargron` hosted on the `mastodon.social` website.
 
 Just make a request to that domain's `/.well-known/webfinger` endpoint, with the `resource` query parameter set to an `acct:` URI.
 

--- a/content/en/user/moderating.md
+++ b/content/en/user/moderating.md
@@ -36,7 +36,7 @@ Choose where the filter will be applied:
 
 ### Hide completely {#filter-hide}
 
-Filtering is usually done client-side, so that disabling a filter will cause filtered statuses to be visible again. However, if you enable "Hide completely", any matching statuses will be disappear completely and will never be delivered to your home or notifications.
+Filtering is usually done client-side, so that disabling a filter will cause filtered statuses to be visible again. However, if you enable "Hide completely", any matching statuses will disappear completely and will never be delivered to your home or notifications.
 
 ### Whole word {#filter-whole}
 

--- a/content/en/user/moving.md
+++ b/content/en/user/moving.md
@@ -27,7 +27,7 @@ Redirecting your account disables posting from that account and displays a "prof
 
 {{< figure src="assets/account-move.png" width="70%" caption="Profile move form" >}}
 
-Moving your account is the same as redirecting your account, but it will also irreversibly force everyone to unfollow your current account and follow your new account, if their software supports the Move activity. Your posts will not be moved, due to technical limitations. There is also a 30 day cooldown period in which you cannot migrate again, so be very careful before using this option!
+Moving your account is the same as redirecting your account, but it will also irreversibly force everyone to unfollow your current account and follow your new account, if their software supports the Move activity. Your posts will not be moved, due to technical limitations. There is also a 30-day cooldown period in which you cannot migrate again, so be very careful before using this option!
 
 While moving your profile should automatically move your followers over, it does not automatically transfer your follows, blocks, mutes, or bookmarks. Those can be imported from [previously exported CSV files](#export).
 

--- a/content/en/user/posting.md
+++ b/content/en/user/posting.md
@@ -35,7 +35,7 @@ You can use a `#hashtag` to make your post discoverable to anyone searching for 
 
 {{< figure src="assets/compose-custom-emoji.png" width="50%" caption="An array of custom emoji are available in the selector" >}}
 
-Each server offers a set of custom emoji you can use, similar to Slack or Discord. You can use an emoji using its shortcode like `:thounking:` or by clicking the emoji face in the compose box and browsing through the "Custom" category. You can also browse through and search for standard unicode emoji.
+Each server offers a set of custom emoji you can use, similar to Slack or Discord. You can use an emoji using its shortcode like `:thounking:` or by clicking the emoji face in the compose box and browsing through the "Custom" category. You can also browse through and search for standard Unicode emoji.
 
 ## Attachments {#attachments}
 

--- a/content/en/user/preferences.md
+++ b/content/en/user/preferences.md
@@ -21,7 +21,7 @@ Mastodon has multiple theme options:
 
 ### Choose your layout {#layout}
 
-Mastodon defaults to a simple, one-column layout with a compose box on the left and a column switcher on the right. You can choose to enable the advanced web interface, which allows you view and pin multiple columns at the same time.
+Mastodon defaults to a simple, one-column layout with a compose box on the left and a column switcher on the right. You can choose to enable the advanced web interface, which allows you to view and pin multiple columns at the same time.
 
 {{< figure src="assets/advanced-web-ui.png" caption="Columns of the advanced web interface using the light theme" >}}
 

--- a/content/en/user/quote-posts.md
+++ b/content/en/user/quote-posts.md
@@ -19,7 +19,7 @@ Quote posts allow you to reference another user's post in your own, while adding
 - Don’t want to be quoted? Disable quoting by default for all posts, or turn off quoting for a specific post
 - Want your thoughts to inspire a wider audience? Keep the default setting enabled to ‘Anyone’.
 
-Quoting is just one way of interacting with existing posts on Mastodon. For more interactions (replies, boost etc) see the [Interacting with Posts](../network#actions) section.
+Quoting is just one way of interacting with existing posts on Mastodon. For more interactions (replies, boosts, etc.) see the [Interacting with Posts](../network#actions) section.
 
 ## How to quote others {#how}
 

--- a/content/en/user/run-your-own.md
+++ b/content/en/user/run-your-own.md
@@ -10,7 +10,7 @@ menu:
 ## Why would you want to run your own Mastodon server?
 
 - Absolute control over your own voice on the web, not subject to anyone else's rules or whims. Your server is your property, with your rules. It will exist as long as you want it to exist.
-- You are *not* isolated on your own server. You can follow anyone on any other server, and they can follow you and you can exchange messages just like if you were on the same server.
+- You are *not* isolated on your own server. You can follow anyone on any other server, and they can follow you, and you can exchange messages just like if you were on the same server.
 - You can either limit sign-ups to be the only one on the server and run it like personal (micro)blog, maintain an invite-only community for family or friends or run a server anyone can sign up on, it's up to you!
 
 {{< hint style="warning" >}}
@@ -29,7 +29,7 @@ Here is what you need:
   **How to get**: DigitalOcean, Hetzner, Exoscale, Scaleway, any of the infinite number of hosting providers. Comes with a monthly or yearly cost that varies depending on hardware specifications.
 - An **e-mail provider**. Mastodon needs to send confirmation links and various notifications through e-mail, and hosting your own SMTP server, while possible, is much more difficult to do reliably than to use a third-party provider.
 
-  **How to get**: Mailgun, SparkPost, Postmark, Sendgrid, any of the infinite number of e-mail hosting providers that expose a SMTP API. Comes with a monthly cost based on volume of e-mails sent.
+  **How to get**: Mailgun, SparkPost, Postmark, Sendgrid, any of the infinite number of e-mail hosting providers that expose an SMTP API. Comes with a monthly cost based on volume of e-mails sent.
 - Optional: **Object storage provider**. Mastodon can save files that you and your users upload on the hard disk drive of the VPS it runs on, however, the hard disk drive is usually not infinite and difficult to upgrade later. An object storage provider gives you practically infinite metered file storage.
 
   **How to get**: Amazon S3, Exoscale, Wasabi, Google Cloud, anything that exposes either an S3-compatible or OpenStack Swift-compatible API. Comes with a monthly cost based on the amount of files stored as well as how often they are accessed.


### PR DESCRIPTION
Bumped into these while editing elsewhere. The spelling ones should be obvious ... there's a few misc JSON missing/extra commas/brackets mixed in, maybe a stray paren, etc.

I could conceivably split up the ones which are just narrowly typo fixes from the "code reformatting", if desired.