### PR TITLE
Add note about streaming server error responses

### DIFF
--- a/content/en/methods/streaming.md
+++ b/content/en/methods/streaming.md
@@ -703,6 +703,25 @@ An example filter change by the user:
 Note that the `payload` property is not present for `filters_changed` events. And for `delete` and `announcements.delete` the payload is a string, not an object.
 {{</hint>}}
 
+## Error responses
+
+For HTTP requests to a non-existent streaming endpoint, the streaming server will respond with an HTTP 400 and a JSON body describing the error:
+
+```json
+{
+  "error": "Unknown channel requested"
+}
+```
+
+For invalid requests within the WebSocket (for example, an incorrect stream name), the server will respond with error JSON:
+
+```json
+{
+  "error": "Unknown stream type",
+  "status":400
+}
+```
+
 ## See also
 
 ### Streaming server


### PR DESCRIPTION
Resolves https://github.com/mastodon/documentation/issues/1505

This is just attempting to solve the "we literally only mention event responses and don't contemplate errors" aspect of that page. Possible future improvement here would be to more exhaustively list error conditions?