### PR TITLE
Add profile bullet to list in user moderating/filter section

### DIFF
--- a/content/en/user/moderating.md
+++ b/content/en/user/moderating.md
@@ -33,6 +33,7 @@ Choose where the filter will be applied:
 * Notifications = matching notifications will not be shown
 * Public timelines = matching statuses will not appear in local/federated timelines
 * Conversations = matching statuses will be hidden in threads and detailed views
+* Profiles = matching statuses will be hidden in profile views
 
 ### Hide completely {#filter-hide}
 


### PR DESCRIPTION
Resolves https://github.com/mastodon/documentation/issues/1332

Replaces https://github.com/mastodon/documentation/pull/1355 (no updates for two years, presumably abandoned)

There was feedback on that PR to add updated images, which I have ignored here - but I think it makes more sense to do a more wholistic post-4.5-release pass over essentially all the docs and update the various UI screenshots with latest. Not sure if this is already baked into the release process or not.