### PR TITLE
Document that media attachment focus x/y may be null

### DIFF
--- a/content/en/entities/MediaAttachment.md
+++ b/content/en/entities/MediaAttachment.md
@@ -216,12 +216,12 @@ May contain subtrees `small` and `original`, as well as various other top-level 
 ### `meta[focus][x]` {#meta-focus-x}
 
 **Description:** Horizontal focal point\
-**Type:** float
+**Type:** {{<nullable>}} Float or null
 
 ### `meta[focus][y]` {#meta-focus-y}
 
 **Description:** Vertical focal point\
-**Type:** float
+**Type:** {{<nullable>}} Float or null
 
 ### `description` {#description}
 


### PR DESCRIPTION
Resolves https://github.com/mastodon/documentation/issues/1700