### PR TITLE
Describe result order of trends

### DIFF
--- a/content/en/methods/trends.md
+++ b/content/en/methods/trends.md
@@ -1,6 +1,6 @@
 ---
 title: trends API methods
-description: View hashtags that are currently being used more frequently than usual.
+description: Listings of tags, statuses, and links with increased activity
 menu:
   docs:
     weight: 10
@@ -17,6 +17,13 @@ aliases: [
 <style>
 #TableOfContents ul ul ul {display: none}
 </style>
+
+## Summary
+
+These endpoints return the relevant trending results for each of tags, statuses,
+and links. Results are returned according to an internal trending score, and not
+guaranteed to be chronologically or lexically sorted. Trending scores are
+periodically recalculated.
 
 ## View trending tags {#tags}
 


### PR DESCRIPTION
Resolves https://github.com/mastodon/documentation/issues/1292

Goal here was just to document the order being different here, as requested by the issue. While in there, made the description more accurate (presumably was legacy of this beings tags only endpoint?)

Possible future improvement would be to describe more somewhere in the guide about how scoring works, and/or differences in the ordering when requested auth'd or not, and how the "preferred languages" interacts as well.