### PR TITLE
Clarify ineligible translation scenario

### DIFF
--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -675,7 +675,7 @@ Translate the status content into some language. Only statuses with Public and U
 ##### Form data parameters
 
 lang
-: String (ISO 639-1 language code). The status content will be translated into this language. Defaults to the user's current locale.
+: String (ISO 639-1 language code). The status content will be translated into this language. Defaults to the user's current locale (which in turn falls back to server default).
 
 ##### Headers
 
@@ -683,6 +683,7 @@ Authorization
 : {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
 
 #### Response
+
 ##### 200: OK
 
 Translating a status in Spanish with content warning and media into English
@@ -740,7 +741,10 @@ Status does not exist
 
 ##### 403: Forbidden
 
-Status is private or direct
+Status has any of:
+
+- Visibility of private or direct
+- A `language` attribute which is ineligible for translation to the target `lang` by the configured backend. This may include "same language" (i.e. `en`->`en`) attempts when not supported.
 
 ```json
 {


### PR DESCRIPTION
Resolves https://github.com/mastodon/documentation/issues/1330

Notes:

- There is a linked issue there around discovering user language, which maybe should be dealt with as well. This narrowly fixes the "we don't explain why this error can happen" portion, which is the main point of the issue.
- This also doesn't challenge the issue of whether the API *should* act this way (ie, should we intercept/override same-language translation requests?) and merely documents what actually occurs.