### PR TITLE
Update default PostgreSQL version to 18 in install docs

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -73,7 +73,7 @@ adduser --disabled-password mastodon
 
 #### Performance configuration (optional) {#performance-configuration-optional}
 
-For optimal performance, you may use [pgTune](https://pgtune.leopard.in.ua/#/) to generate an appropriate configuration and edit values in `/etc/postgresql/17/main/postgresql.conf` before restarting PostgreSQL with `systemctl restart postgresql`.
+For optimal performance, you may use [pgTune](https://pgtune.leopard.in.ua/#/) to generate an appropriate configuration and edit values in `/etc/postgresql/18/main/postgresql.conf` before restarting PostgreSQL with `systemctl restart postgresql`.
 
 #### Creating a user {#creating-a-user}
 


### PR DESCRIPTION
Updates the PostgreSQL configuration path reference from version 17 to 18 to reflect the current default version from apt.postgresql.org.

Ref: 0b15ac1