### PR TITLE
Add note about tag limit to timeline doc

### DIFF
--- a/content/en/methods/timelines.md
+++ b/content/en/methods/timelines.md
@@ -137,6 +137,10 @@ Authorization
 
 ##### Query parameters
 
+{{< hint style="info" >}}
+Note that there is a limit to the number of tags that will be applied from each query param (defaults to 4 total tags). Keep this in mind when using the `any`, `all`, and `none` params.
+{{</ hint >}}
+
 any[]
 : Array of String. Return statuses that contain any of these additional tags.
 


### PR DESCRIPTION
Resolves https://github.com/mastodon/documentation/issues/1324

See background discussion there.

Possible future improvement here would be to expand on how there query params interact with each other, with the primary tag from the `id`, and with the limit. For now, just trying to solve the "there is a limit but we dont mention the limit" portion.