### PR TITLE
Restore TOC heading level config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,7 @@ disablePathToLower = true
 
 [markup]
   [markup.tableOfContents]
-    endLevel = 2
+    endLevel = 3
     ordered = false
     startLevel = 1
   [markup.goldmark.renderer]

--- a/content/en/user/quote-posts.md
+++ b/content/en/user/quote-posts.md
@@ -7,6 +7,10 @@ menu:
     parent: user
 ---
 
+<style>
+#TableOfContents ul ul ul {display: none}
+</style>
+
 ## What are quote posts? {#what}
 
 Quote posts allow you to reference another user's post in your own, while adding your own commentary.


### PR DESCRIPTION
Background: https://github.com/mastodon/documentation/pull/1717#discussion_r2524197416

Related, I think because we skip from `##` to `####` in that bottom faq section on this page, we are hitting this hugo bug/behavior -- https://discourse.gohugo.io/t/empty-li-item-in-toc-is-generated/50665/4 / https://github.com/gohugoio/hugo/issues/7128

If someone were so inclined they could probably do a more exhaustive overhaul of header levels across the repo here, and remove this style/display hack in favour of a configured endLevel and consistent page markup ... that said, for now this restores the previous TOC generation and makes this page act like the others in it's use of that approach.