### PR TITLE
Replace code fencing with more relevant styles

### DIFF
--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -27,7 +27,7 @@ As with `LOCAL_DOMAIN`, `WEB_DOMAIN` cannot be safely changed once set, as this 
 
 To install Mastodon on `mastodon.example.com` in such a way it can serve `@alice@example.com`, set `LOCAL_DOMAIN` to `example.com` and `WEB_DOMAIN` to `mastodon.example.com`. This also requires additional configuration on the server hosting `example.com` to redirect requests from `https://example.com/.well-known/webfinger` to `https://mastodon.example.com/.well-known/webfinger`. For instance, with nginx, the configuration could look like the following:
 
-```
+```nginx
 location /.well-known/webfinger {
   add_header Access-Control-Allow-Origin '*';
   return 301 https://mastodon.example.com$request_uri;

--- a/content/en/admin/elasticsearch.md
+++ b/content/en/admin/elasticsearch.md
@@ -51,7 +51,7 @@ apt install elasticsearch
 
 Before you start Elasticsearch, you might want to limit its RAM consumption. A RAM limit can be set be creating a new file `/etc/elasticsearch/jvm.options.d/limit-ram.options` with the following content:
 
-```
+```java-properties
 # Limit RAM size to 24 GB
 -Xms16g
 -Xmx24g

--- a/content/en/admin/optional/tor.md
+++ b/content/en/admin/optional/tor.md
@@ -171,7 +171,7 @@ systemctl status nginx.service
 
 When this happens you may uncomment the following line in your nginx.conf:
 
-```text
+```nginx
 # server_names_hash_bucket_size 64;
 ```
 

--- a/content/en/admin/scaling.md
+++ b/content/en/admin/scaling.md
@@ -53,7 +53,7 @@ The more streaming server processes that you run, the more database connections 
 
 An example nginx configuration to route traffic to three different processes on `PORT` 4000, 4001, and 4002 is as follows:
 
-```text
+```nginx
 upstream streaming {
     least_conn;
     server 127.0.0.1:4000 fail_timeout=0;

--- a/content/en/methods/instance.md
+++ b/content/en/methods/instance.md
@@ -718,10 +718,6 @@ Invalid or missing Authorization header, if the admin has chosen to show domain 
 
 The admin has chosen to show domain blocks to no one. The response body is empty; only the HTTP 404 error code is relevant.
 
-```text
-
-```
-
 ---
 
 ## View extended description {#extended_description}

--- a/content/en/methods/media.md
+++ b/content/en/methods/media.md
@@ -224,10 +224,6 @@ The media file was processed, and a `url` to the processed media is available.
 
 The media attachment is still being processed
 
-```json
-
-```
-
 ##### 401: Unauthorized
 
 Invalid or missing Authorization header.

--- a/content/en/methods/timelines.md
+++ b/content/en/methods/timelines.md
@@ -310,9 +310,6 @@ Statuses in your home timeline will be returned
 
 Home feed is regenerating
 
-```text
-```
-
 ##### 401: Unauthorized
 
 Invalid or missing Authorization header.


### PR DESCRIPTION
Two things in one:

- In a few spots around nginx config (which we use elsewhere, and does have syntax highlighting) we had no syntax or just "text", replace those with nginx.
- In a few spots we were code fencing ... nothing ... in a way where the surrounding context makes it clear that the http response code is what's important (and there's no response body), so it seems simpler to just remove

RE: https://github.com/mastodon/documentation/blob/main/DOCSTYLE.md?plain=1#L41