### PR TITLE
Fix code indent and list numbering on ES docs page

### DIFF
--- a/content/en/admin/elasticsearch.md
+++ b/content/en/admin/elasticsearch.md
@@ -160,13 +160,15 @@ Creating Elasticsearch indicies could require more memory than the JVM (Java Vir
 
 1. Create and open a file in the directory ```/etc/elasticsearch/jvm.options.d/``` (for example: ```nano /etc/elasticsearch/jvm.options.d/ram.options```)
 2. Add following text and edit the allocated memory to your needs. As a rule of thumb, Elasticsearch should use about 25%-50% of your available memory. Do not allocate more memory than available.
-```
-# Xms represents the initial size of total heap space
-# Xmx represents the maximum size of total heap space
-# Both values should be the same
--Xms2048m
--Xmx2048m
-```
+
+    ```java-properties
+    # Xms represents the initial size of total heap space
+    # Xmx represents the maximum size of total heap space
+    # Both values should be the same
+    -Xms2048m
+    -Xmx2048m
+    ```
+
 3. Save the file.
 4. Restart Elasticsearch using ```systemctl restart elasticsearch```.
 5. Retry creating Elasticsearch indicies. If Elasticsearch still crashes, try to set a higher number.


### PR DESCRIPTION
Noticed while doing https://github.com/mastodon/documentation/pull/1816

Currently the ordered list here gets reset by where the code block is, and the code block is not aligned with it's bullet.

Before:

<img width="818" height="714" alt="Screenshot 2025-11-18 at 15 50 11" src="https://github.com/user-attachments/assets/9f2562f4-2b71-4658-bd5a-1c903cdf2bf1" />

After:

<img width="823" height="749" alt="Screenshot 2025-11-18 at 15 51 28" src="https://github.com/user-attachments/assets/99973b16-2323-44ca-b7ac-7a4c8fd80c38" />
