### PR TITLE
Add default value for filters v2 expires_in attribute

### DIFF
--- a/content/en/methods/filters.md
+++ b/content/en/methods/filters.md
@@ -201,7 +201,7 @@ filter_action
 : String. The policy to be applied when the filter is matched. Specify `warn`, `hide` or `blur`.
 
 expires_in
-: Integer. How many seconds from now should the filter expire?
+: Integer. How many seconds from now should the filter expire? Defaults to never expire.
 
 keywords_attributes[][keyword]
 : String. A keyword to be added to the newly-created filter group.


### PR DESCRIPTION
Resolves https://github.com/mastodon/documentation/issues/1216

The v1 method further down this same page had some language for this, just adding to v2 here.

There are some default/optional/etc sort of meta discussions on that linked issue, which ... a) are not resolved/addressed here, b) are probably better addressed in an API-wide doc guideline re: defaults/nulls/missing/etc, and not just on one or two methods.