### PR TITLE
Clarify default paginated result order

### DIFF
--- a/content/en/api/guidelines.md
+++ b/content/en/api/guidelines.md
@@ -76,7 +76,7 @@ In this case, you may retrieve the `Link` header and parse it for links to the o
 - The URL will be surrounded by angle brackets (`<>`), and the link relation will be surrounded by double quotes (`""`) and prefixed with `rel=`.
 - The value of the link relation will be either `prev` or `next`.
 
-Following the `next` link should show you older results. Following the `prev` link should show you newer results.
+Unless otherwise documented by a specific API method (or in situations where a sort order is not sensible or relevant) results can be assumed to be in reverse chronological order (most recent first). Following the `next` link should show you older results. Following the `prev` link should show you newer results.
 
 ## Deprecations {#deprecations}
 


### PR DESCRIPTION
Resolves https://github.com/mastodon/documentation/issues/1226

I believe this captures what currently happens ... but I don't know how much of that is purposeful vs historical accident of how the various pagination/APIs evolved over time. Other options here:

- Soften this language a bit, like "Results are mostly in..." or "Results are usually in..." or something?
- Explicitly call out that it's not specified? "Results are generally in reverse chronological order, however this is not guaranteed and clients should retrieve records first and sort them later when relevant" (?)