### PR TITLE
Add notes to user/admin areas about translation basics

### DIFF
--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -768,10 +768,19 @@ Prefix for the OTEL service names. The services names will be `$prefix/web` and 
 
 What character to use in service names when differentiating between different services. Defaults to `/` (i.e. `mastodon/web`).
 
-
 #### `OTEL_EXPORTER_OTLP_ENDPOINT`
 
 URL of the OLTP server to send the traces to. OpenTelemetry instrumentation is disabled if this variable is not set. No default (empty value).
+
+### Translation services {#translation}
+
+Mastodon supports integration with [DeepL] and [LibreTranslate] as backend language translation engines. Both services require separate setup and for configuration of Mastodon (via environment variables) to understand how to use them.
+
+- DeepL needs `DEEPL_API_KEY` and `DEEPL_PLAN` (defaults to "free")
+- LibreTranslate needs `LIBRE_TRANSLATE_API_KEY` and `LIBRE_TRANSLATE_ENDPOINT`
+
+[DeepL]: https://www.deepl.com
+[LibreTranslate]: https://libretranslate.com
 
 ## File storage {#files}
 

--- a/content/en/user/network.md
+++ b/content/en/user/network.md
@@ -125,3 +125,7 @@ Opening a list will load that list's timeline. List timelines contain only posts
 ## Syndication Feeds {#syndication}
 
 Every account and tag page provide an RSS feed for syndication onto other platforms. Those feeds are auto-discoverable from the account and tag pages.
+
+## Translation
+
+When a post is in a language other than what your account is set to understand, a "Translate" button will appear next to the post content. Clicking this button issues a request to translate the content to the server, and will replace that content with translated results. This feature requires the server to have configured support for a translation service, and so may not be available on all servers.


### PR DESCRIPTION
Resolves https://github.com/mastodon/documentation/issues/1058 (the remaining parts)

That issue asked for user- and admin- facing guides for translation, which are done here. There are some separate issues about API usage, most of which have been done by other (linked to issue) PRs, and one of which (legal questions) is still captured in another open issue.

Possible followup here could be things like:

- In user guide, go into more detail about the exact interactions between the language preferences and timelines/translations
- In admin guide, go into more detail about ways to setup the translation services

For first pass here, I'm really just trying to cross the "we literally dont mention this feature" (other than in API docs, which are   actually pretty good) bar.