### PR TITLE
Add example onion to alt domains env var in tor guide

### DIFF
--- a/content/en/admin/optional/tor.md
+++ b/content/en/admin/optional/tor.md
@@ -148,6 +148,12 @@ server {
 }
 ```
 
+Also update your `.env.production`:
+
+```text
+ALTERNATE_DOMAINS=mastodon.qKnFwnNH2oH4QhQ7CoRf7HYj8wCwpDwsa8ohJmcPG9JodMZvVA6psKq7qKnFwnNH2oH4QhQ7CoRf7HYj8wCwpDwsa8ohJmcPG9JodMZvVA6psKq7.onion
+```
+
 Replace the long hash provided here with your Tor domain located in the file at `/var/lib/tor/onion_service/hostname`. This should also be reflected in the `Onion-Location` header in the snippets file.
 
 Note that the onion hostname has been prefixed with “mastodon.”. Your Tor address acts as a wildcard domain. All subdomains will be routed through, and you can configure Nginx to respond to any subdomain you wish. If you do not wish to host any other services on your tor address you can omit the subdomain, or choose a different subdomain.


### PR DESCRIPTION
Resolves https://github.com/mastodon/documentation/issues/1284

This was attempted in https://github.com/mastodon/documentation/pull/1366 but that needs rebase and has not been updated in a while. I suspect there are still useful things in there ... but also the rebase may reveal some of it has been handled separately in the interim.

This change handles JUST the request of that linked issue, without any of the other improvements from the outdated PR.