### PR TITLE
fix: Remove "you have posted" from statuses/:id/quote

### DIFF
--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -841,7 +841,7 @@ Status does not exist or is private
 GET /api/v1/statuses/:id/quotes HTTP/1.1
 ```
 
-View quotes of a status you have posted.
+View quotes of a status.
 
 **Returns:** Array of [Status]({{< relref "entities/status" >}})\
 **OAuth:** User token + `read:statuses`.\


### PR DESCRIPTION
https://github.com/mastodon/documentation/pull/1733 fixed the content to remove the suggestion that only quotes of the statuses owned by the user token could be viewed.

It missed the description text, which still said "View quotes of a status you have posted".

Fix that.