### PR TITLE
Add migration summary to user moving page

### DIFF
--- a/content/en/user/moving.md
+++ b/content/en/user/moving.md
@@ -7,6 +7,26 @@ menu:
     parent: user
 ---
 
+## Summary
+
+If your current server is going to shut down, has changed policies, is not being maintained, or for whatever other reason is no longer working for you, you can migrate your account to a new server and preserve much of your account content and relationships.
+
+Follow these steps to migrate accounts:
+
+1. Create a new Mastodon account on another server. Try to choose one that you think will work for you long term, or make your own.
+2. Set up the new account with your profile, bio, avatar and header, etc. This is not strictly necessary from a technical perspective, but it will help anyone who encounters it trust that it really is you. You may want to send out a post from the new account announcing the move as well.
+3. From the old account, [export a list of people you follow](#export). If you are following people who require approval for followers, they will have to re-approve you.
+4. From the new account, import that just-exported list of people you follow (and any other lists you exported).
+5. Create an alias from the old to new account. From the new account, go to Preferences > Account and find “Moving from a different account”. Click “create an account alias”. Enter your old account handle and click “Create alias”.
+
+   {{< hint style="warning" >}}
+   You haven't changed anything yet, you have only prepared. Pause at this point and see if you have anything in your old account you will need access to, such as notifications and DMs. Once you proceed to the next step you will no longer have access to your old account.
+   {{< /hint >}}
+
+6. Redirect your old account to your new account. In your old account, go to Preferences > Account, find “Moving to a different account” and click “configure it here”. Enter your new account handle and your old account password (because this is on the old account server) and click "Move followers". If you see an error like “not an alias of this account”, make sure you have completed the "alias" step above. You may need to wait up to 24 hours and try again.
+
+At this point your old account will no longer be accessible to you and your server will begin notifying the people who follow you of your new handle (they will be automatically switched to follow your new account). If you have enough followers, it may batch these requests up, so you may see new followers appear on your new account gradually as that happens.
+
 ## Exporting your information {#export}
 
 {{< figure src="assets/export.png" width="70%" caption="The data export page in settings" >}}


### PR DESCRIPTION
Resolves https://github.com/mastodon/documentation/issues/1199

This is borrowed almost entirely from the linked blog post. I did some very lightweight copy editing and updated some terms (instance -> server, etc). All credit to blog author, all mistakes are on me.

There is probably room for further followup here:

- Some of the sections below this on the same page could use a once-over
- The suggestion in the linked issue to clarify, within the UX, whether you are on the old or new server is a good one. (We cant literally write "old" and "new", but we can be way more verbose about what you are attempting)