### PR TITLE
Add note about optional stream param when establishing connection

### DIFF
--- a/content/en/methods/streaming.md
+++ b/content/en/methods/streaming.md
@@ -643,7 +643,8 @@ access_token
 : {{%optional%}} String. A user-authorized OAuth token.  Provided as a legacy alternative to `Authorization` header as [explained](#authorization) above.
 
 stream
-: {{<required>}} String. The stream to watch for events. See [Streams](#streams) for possible values.
+: {{<required>}} String. When attempting to watch a single stream for events. See [Streams](#streams) for possible values.
+: {{%optional%}} String. When initiating a general connection without a specific subscription target.
 
 list
 : String. When `stream` is set to `list`, use this parameter to specify the list ID.


### PR DESCRIPTION
Resolves https://github.com/mastodon/documentation/issues/1797 (portions already handled by other changes, this gets the final remaining point)

This is the lowest-diff way I could think of to handle this without rewriting or repeating much of the surrounding establishing a connection section. Even though its logically odd to call something required and also optional right next to each other ... hopefully its clear from the language and context what is going on. There's some precedent for this elsewhere when things are declared optional and then described inline about when they are required/present. Open to ideas.