### PR TITLE
fix: Use correct `quoted_status` property, update `quoted_status` description

### DIFF
--- a/content/en/entities/Quote.md
+++ b/content/en/entities/Quote.md
@@ -78,21 +78,21 @@ aliases: [
 **Description:** The state of the quote. Unknown values should be treated as `unauthorized`.\
 **Type:** String (Enumerable, oneOf)\
 `pending` = The quote has not been acknowledged by the quoted account yet, and requires authorization before being displayed.\
-`accepted` = The quote has been accepted and can be displayed. This is one of the few cases where `status` is non-null.\
+`accepted` = The quote has been accepted and can be displayed. `quoted_status` is non-null.\
 `rejected` = The quote has been explicitly rejected by the quoted account, and cannot be displayed.\
 `revoked` = The quote has been previously accepted, but is now revoked, and thus cannot be displayed.\
 `deleted` = The quote has been approved, but the quoted post itself has now been deleted.\
 `unauthorized` = The quote has been approved, but cannot be displayed because the user is not authorized to see it.\
-`blocked_account` = The quote has been approved, but should not be displayed because the user has blocked the account being quoted. This is one of the few cases where `status` is non-null.\
-`blocked_domain` = The quote has been approved, but should not be displayed because the user has blocked the domain of the account being quoted. This is one of the few cases where `status` is non-null.\
-`muted_account` = The quote has been approved, but should not be displayed because the user has muted the the account being quoted. This is one of the few cases where `status` is non-null.
+`blocked_account` = The quote has been approved, but should not be displayed because the user has blocked the account being quoted. `quoted_status` is non-null.\
+`blocked_domain` = The quote has been approved, but should not be displayed because the user has blocked the domain of the account being quoted. `quoted_status` is non-null.\
+`muted_account` = The quote has been approved, but should not be displayed because the user has muted the the account being quoted. `quoted_status` is non-null.
 **Version history:**\
 4.4.0 - added\
 4.5.0 - added `blocked_account`, `blocked_domain` and `muted_account`
 
 ### `quoted_status` {#quoted_status}
 
-**Description:** The status being quoted, if the quote has been accepted. This will be `null`, unless the `state` attribute is `accepted`.\
+**Description:** The status being quoted, if the quote has been accepted. This will be `null`, unless the `state` attribute is `accepted`, `blocked_account`, `blocked_domain`, or `muted_account`.\
 **Type:** {{<nullable>}} [Status]({{< relref "entities/status" >}}) or null\
 **Version history:**\
 4.4.0 - added


### PR DESCRIPTION
Correct the description for the `state` property values to reference `quoted_status` instead of `status`.

Simplify the description -- how many times it's non-null isn't relevant.

Correct the description of the `quoted_status` property to list all the states it is non-null.