### PR TITLE
Add architecture details to development overview page

### DIFF
--- a/content/en/dev/overview.md
+++ b/content/en/dev/overview.md
@@ -11,15 +11,26 @@ menu:
 #TableOfContents {display: none}
 </style>
 
-Mastodon is a Ruby on Rails application with a React.js front-end. It follows standard practices of those frameworks, so if you are already familiar with Rails or React.js, you will not find any surprises here.
+## Introduction
+
+Mastodon is a Ruby on Rails application with a React.js front-end. It follows standard practices of those frameworks ([MVC] Architecture, [REST] APIs, etc), so if you are already familiar with Rails or React.js, you will not find any surprises here.
 
 The best way of working with Mastodon in a development environment is installing all the dependencies on your system, rather than using Docker or Vagrant. You need Ruby, Node.js, PostgreSQL and Redis, which is a pretty standard set of dependencies for Rails applications.
 
-Tutorials for installing these dependencies can be found on the “Installing from source” page in the Running Mastodon section of the documentation. After following the installation guide in the Running Mastodon section, see the “Setting up a dev environment” page for further instructions on how to configure your environment for development.
+Tutorials for installing these dependencies can be found on the [Installing from source](../admin/install) page in the Running Mastodon section of the documentation. After following the installation guide in the Running Mastodon section, see the [Setting up a dev environment](../dev/setup) page for further instructions on how to configure your environment for development.
 
 ### Environments {#environments}
 
-An “environment” is a set of configuration values intended for a specific use case. Some environments could be: development, in which you intend to change the code; test, in which you intend to run the automated test suite; staging, which is meant to preview the code to end-users; and production, which is intended to face end-users. Mastodon comes with configurations for development, testing and production.
+An “environment” is a set of configuration values intended for a specific use case.
+
+Typical environments are:
+
+- `development` -- for changing and maintaining the application locally
+- `test` -- for running the automated test suite
+- `staging` -- for previewing features to end-users
+- `production` -- for real world deployment and usage
+
+Mastodon comes with configurations for development, testing and production.
 
 The default value of `RAILS_ENV` is `development`, so you don’t need to set anything extra to run Mastodon in development mode. In fact, all of Mastodon’s configuration has correct defaults for the development environment, so you do not need an `.env` file unless you need to customize something. Here are some of the different behaviours between the development environment and the production environment:
 
@@ -29,4 +40,7 @@ The default value of `RAILS_ENV` is `development`, so you don’t need to set an
 - Caching is disabled by default
 - An admin account with the e-mail `admin@localhost:3000` and password `mastodonadmin` is created automatically during `db:seed`
 
-It should be noted that the Docker configuration distributed with Mastodon is optimized for the production environment, and so is an extremely bad fit for development. The Vagrant configuration, on the other hand, is meant specifically for development and not production use.
+It should be noted that the top-level Docker configuration distributed with Mastodon is optimized for the production environment, and so is an extremely bad fit for development. The Vagrant configuration and the Docker configuration nested in `.devcontainer/` on the other hand, are meant specifically for development and not production use.
+
+[MVC]: https://developer.mozilla.org/en-US/docs/Glossary/MVC
+[REST]: https://developer.mozilla.org/en-US/docs/Glossary/REST


### PR DESCRIPTION
Replaces https://github.com/mastodon/documentation/pull/1085

Resolves https://github.com/mastodon/documentation/issues/1008

This is technically a rebase/replace of that linked PR, with some changes:

- A good chunk of the changes have either been fixed on this page, or are mentioned elsewhere in the docs, since this PR was made - so I removed portions of it
- I applied whatever wording/feedback was still relevant after those removals
- I removed the attached image and architecture bullet points in favour of just linking to some relevant doc pages elsewhere ... in my opinion these basics of working with web apps are so general and not at all specific to Mastodon that it feels weird to include them. Happy to revise that if  anyone feels differently.
- Added links to other pages in docs where relevant
- Small edit to docker/vagrant details near page bottom to reflect current situation in the app

Despite the changes I have preserved auther credit for original contributor because the spirit of the changes is more or less the same as their intention (I think/hope!). As always, credit to them, and mistakes are mine.