### PR TITLE
Fix wording of USERNAME descriptions for two tootctl commands

### DIFF
--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -167,7 +167,7 @@ Modify a user account's role, email, active status, approval mode, or 2FA requir
 Delete a user account with the given USERNAME.
 
 `USERNAME`
-: Local username for the new account. {{<required>}}
+: Local username of the account to delete. {{<required>}}
 
 **Version history:**\
 2.6.0 - added
@@ -181,7 +181,7 @@ Delete a user account with the given USERNAME.
 Request a backup for a user account with the given USERNAME. The backup will be created in Sidekiq asynchronously, and the user will receive an email with a link to it once it's done.
 
 `USERNAME`
-: Local username for the new account. {{<required>}}
+: Local username of the account to backup. {{<required>}}
 
 **Version history:**\
 2.6.0 - added


### PR DESCRIPTION
The previous descriptions for the `USERNAME` to be passed to `tootctl accounts delete` and `tootctl accounts backup` both read "Local username for the new account." (the same as `tootctl accounts create`) – this may have been a mistake caused by copy/pasting the description some time in the past.

I've reworded each of these:
- `tootctl accounts delete`
  - "Local username of the account to delete."
- `tootctl accounts backup`
  - "Local username of the account to backup."