### PR TITLE
add missing options from statuses remove

### DIFF
--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -913,8 +913,24 @@ This is a computationally heavy procedure that creates extra database indices be
 `--days N`
 : How old statuses have to be before they are removed. Defaults to 90.
 
+`--batch_size N`
+: Number of records in each batch. Defaults to 1000.
+
+`--continue`
+: If remove is not completed, execute from the previous continuation
+
+`--clean_followed`
+: Include the status of remote accounts that are followed by local accounts as candidates for remove
+
+`--skip_status_remove`
+: Skip status remove (run only cleanup tasks)
+
 `--skip-media-remove`
 : Skips removing the media, in case S3 errors out. Defaults to false.
+
+`--compress_database`
+: Compress database and update the statistics. This option locks the table for a long time, so run it offline
+
 
 **Version history:**\
 2.8.0 - added\

--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -917,10 +917,10 @@ This is a computationally heavy procedure that creates extra database indices be
 : Number of records in each batch. Defaults to 1000.
 
 `--continue`
-: If remove is not completed, execute from the previous continuation
+: If remove is not completed, execute from the previous continuation.
 
 `--clean_followed`
-: Include the status of remote accounts that are followed by local accounts as candidates for remove
+: Include the status of remote accounts that are followed by local accounts as candidates for remove.
 
 `--skip_status_remove`
 : Skip status remove (run only cleanup tasks)
@@ -929,7 +929,7 @@ This is a computationally heavy procedure that creates extra database indices be
 : Skips removing the media, in case S3 errors out. Defaults to false.
 
 `--compress_database`
-: Compress database and update the statistics. This option locks the table for a long time, so run it offline
+: Compress database and update the statistics. This option locks the table for a long time, so run it offline.
 
 
 **Version history:**\


### PR DESCRIPTION
idk i see the options here: 
https://github.com/mastodon/mastodon/blob/2e30044a374811bc94fd62a8159cb2c9ffe18a4d/lib/mastodon/cli/statuses.rb#L9-L15

and it seems like they are just out of date in the docs

kept them in the same order as in the source. 
