### PR TITLE
Add for_bots to notification policy

### DIFF
--- a/content/en/entities/NotificationPolicy.md
+++ b/content/en/entities/NotificationPolicy.md
@@ -46,6 +46,13 @@ aliases: [
 **Version history:**\
 4.3.0 - added
 
+### `for_bots` {#for_bots}
+
+**Description:** Whether to `accept`, `filter` or `drop` notifications from accounts marked as automated. `drop` will prevent creation of the notification object altogether (without preventing the underlying activity), `filter` will cause it to be marked as filtered, and `accept` will not affect its processing.\
+**Type:** String (one of `accept`, `filter` or `drop`)\
+**Version history:**\
+4.6.0 - added
+
 ### `summary` {#summary}
 
 **Description:** Summary of the filtered notifications\
@@ -77,6 +84,7 @@ aliases: [
   "for_new_accounts": "accept",
   "for_private_mentions": "drop",
   "for_limited_accounts": "filter",
+  "for_bots": "accept",
   "summary": {
     "pending_requests_count": 0,
     "pending_notifications_count": 0

--- a/content/en/methods/notifications.md
+++ b/content/en/methods/notifications.md
@@ -488,6 +488,7 @@ The response body contains the current notifications filtering policy for the us
   "for_new_accounts": "accept",
   "for_private_mentions": "drop",
   "for_limited_accounts": "filter",
+  "for_bots": "accept",
   "summary": {
     "pending_requests_count": 0,
     "pending_notifications_count": 0
@@ -541,6 +542,9 @@ for_private_mentions
 
 for_limited_accounts
 : String. Whether to `accept`, `filter` or `drop` notifications from accounts that were limited by a moderator. `drop` will prevent creation of the notification object altogether (without preventing the underlying activity), `filter` will cause it to be marked as filtered, and `accept` will not affect its processing.
+
+for_bots
+: String. Whether to `accept`, `filter` or `drop` notifications from accounts that were marked as automated. `drop` will prevent creation of the notification object altogether (without preventing the underlying activity), `filter` will cause it to be marked as filtered, and `accept` will not affect its processing.
 
 
 #### Response


### PR DESCRIPTION
Add the for_bots flag to the notification policy
entity, the GET endpoint and the PUT endpoint,
including the examples.

Related code PR: https://github.com/mastodon/mastodon/pull/38809