### PR TITLE
Add `thumbnail[description]` property to `Instance` for 4.6.0

### DIFF
--- a/content/en/entities/Instance.md
+++ b/content/en/entities/Instance.md
@@ -28,7 +28,7 @@ aliases: [
   },
   "thumbnail": {
     "url": "https://files.mastodon.social/site_uploads/files/000/000/001/@1x/57c12f441d083cde.png",
-	"description": "Colourful illustration of a Mastodon (a sort of elephant) carrying a bindle and joining a group of other Mastodons. The other Mastodons have many different colours and are holding up a Welcome sign.",
+    "description": "Colourful illustration of a Mastodon (a sort of elephant) carrying a bindle and joining a group of other Mastodons. The other Mastodons have many different colours and are holding up a Welcome sign.",
     "blurhash": "UeKUpFxuo~R%0nW;WCnhF6RjaJt757oJodS$",
     "versions": {
       "@1x": "https://files.mastodon.social/site_uploads/files/000/000/001/@1x/57c12f441d083cde.png",

--- a/content/en/entities/Instance.md
+++ b/content/en/entities/Instance.md
@@ -28,6 +28,7 @@ aliases: [
   },
   "thumbnail": {
     "url": "https://files.mastodon.social/site_uploads/files/000/000/001/@1x/57c12f441d083cde.png",
+	"description": "Colourful illustration of a Mastodon (a sort of elephant) carrying a bindle and joining a group of other Mastodons. The other Mastodons have many different colours and are holding up a Welcome sign.",
     "blurhash": "UeKUpFxuo~R%0nW;WCnhF6RjaJt757oJodS$",
     "versions": {
       "@1x": "https://files.mastodon.social/site_uploads/files/000/000/001/@1x/57c12f441d083cde.png",
@@ -507,6 +508,13 @@ aliases: [
 **Type:** String (URL)\
 **Version history:**\
 4.0.0 - added
+
+#### `thumbnail[description]` {#thumbnail-description}
+
+**Description:** The thumbnail's alt text (a description of the image to help people with visual impairments understand its content).\
+**Type:** String\
+**Version history:**\
+4.6.0 - added
 
 #### `thumbnail[blurhash]` {{<optional>}} {#blurhash}
 

--- a/content/en/methods/instance.md
+++ b/content/en/methods/instance.md
@@ -32,7 +32,8 @@ Obtain general information about the server.
 4.1.0 - added `configuration.urls.status`\
 4.2.0 - added `registrations.url`\
 4.3.0 - added `configuration.vapid.public_key`, `api_versions`, `configuration.accounts.max_pinned_statuses`, `icon`\
-4.4.0 - added `configuration.urls.about`, `configuration.urls.privacy_policy`, `configuration.urls.terms_of_service`, `registrations.min_age`, `registrations.reason_required`, `configuration.limited_federation`
+4.4.0 - added `configuration.urls.about`, `configuration.urls.privacy_policy`, `configuration.urls.terms_of_service`, `registrations.min_age`, `registrations.reason_required`, `configuration.limited_federation`\
+4.6.0 - added `thumbnail.description`
 
 #### Response
 
@@ -52,6 +53,7 @@ Obtain general information about the server.
   },
   "thumbnail": {
     "url": "https://files.mastodon.social/site_uploads/files/000/000/001/@1x/57c12f441d083cde.png",
+		"description": "Colourful illustration of a Mastodon (a sort of elephant) carrying a bindle and joining a group of other Mastodons. The other Mastodons have many different colours and are holding up a Welcome sign.",
     "blurhash": "UeKUpFxuo~R%0nW;WCnhF6RjaJt757oJodS$",
     "versions": {
       "@1x": "https://files.mastodon.social/site_uploads/files/000/000/001/@1x/57c12f441d083cde.png",

--- a/content/en/methods/instance.md
+++ b/content/en/methods/instance.md
@@ -53,7 +53,7 @@ Obtain general information about the server.
   },
   "thumbnail": {
     "url": "https://files.mastodon.social/site_uploads/files/000/000/001/@1x/57c12f441d083cde.png",
-		"description": "Colourful illustration of a Mastodon (a sort of elephant) carrying a bindle and joining a group of other Mastodons. The other Mastodons have many different colours and are holding up a Welcome sign.",
+    "description": "Colourful illustration of a Mastodon (a sort of elephant) carrying a bindle and joining a group of other Mastodons. The other Mastodons have many different colours and are holding up a Welcome sign.",
     "blurhash": "UeKUpFxuo~R%0nW;WCnhF6RjaJt757oJodS$",
     "versions": {
       "@1x": "https://files.mastodon.social/site_uploads/files/000/000/001/@1x/57c12f441d083cde.png",


### PR DESCRIPTION
- Adds `thumbnail[description]` property to `Instance` method for 4.6.0
  - Related: https://github.com/mastodon/mastodon/pull/38796 and https://github.com/mastodon/mastodon/pull/38801