### PR TITLE
Sort API method pages alphabetically in sidebar

### DIFF
--- a/content/en/methods/accounts.md
+++ b/content/en/methods/accounts.md
@@ -3,7 +3,6 @@ title: accounts API methods
 description: Methods concerning accounts and profiles.
 menu:
   docs:
-    weight: 20
     name: accounts
     parent: methods
     identifier: methods-accounts

--- a/content/en/methods/admin/_index.md
+++ b/content/en/methods/admin/_index.md
@@ -3,7 +3,6 @@ title: admin API methods
 description: View and manage administrative information.
 menu:
   docs:
-    weight: 80
     name: admin
     parent: methods
     identifier: methods-admin

--- a/content/en/methods/announcements.md
+++ b/content/en/methods/announcements.md
@@ -3,7 +3,6 @@ title: announcements API methods
 description: For announcements set by administration.
 menu:
   docs:
-    weight: 90
     name: announcements
     parent: methods-instance
     identifier: methods-announcements

--- a/content/en/methods/apps.md
+++ b/content/en/methods/apps.md
@@ -3,7 +3,6 @@ title: apps API methods
 description: Register client applications that can be used to obtain OAuth tokens.
 menu:
   docs:
-    weight: 10
     name: apps
     parent: methods
     identifier: methods-apps

--- a/content/en/methods/async_refreshes.md
+++ b/content/en/methods/async_refreshes.md
@@ -3,7 +3,6 @@ title: Experimental async refreshes API methods
 description: Methods concerning async refreshes
 menu:
   docs:
-    weight: 20
     name: async_refreshes
     parent: methods
     identifier: methods-async-refreshes

--- a/content/en/methods/blocks.md
+++ b/content/en/methods/blocks.md
@@ -3,7 +3,6 @@ title: blocks API methods
 description: View your blocks. See also accounts/:id/{block,unblock}
 menu:
   docs:
-    weight: 40
     name: blocks
     parent: methods-accounts
     identifier: methods-blocks

--- a/content/en/methods/bookmarks.md
+++ b/content/en/methods/bookmarks.md
@@ -3,7 +3,6 @@ title: bookmarks API methods
 description: View your bookmarks. See also statuses/:id/{bookmark,unbookmark}
 menu:
   docs:
-    weight: 10
     name: bookmarks
     parent: methods-accounts
     identifier: methods-bookmarks

--- a/content/en/methods/conversations.md
+++ b/content/en/methods/conversations.md
@@ -5,7 +5,6 @@ description: >-
   containing a post with "direct" visibility.)
 menu:
   docs:
-    weight: 10
     name: conversations
     parent: methods-timelines
     identifier: methods-conversations

--- a/content/en/methods/custom_emojis.md
+++ b/content/en/methods/custom_emojis.md
@@ -5,7 +5,6 @@ description: >-
   profiles or statuses.
 menu:
   docs:
-    weight: 30
     name: custom_emojis
     parent: methods-instance
     identifier: methods-custom_emojis

--- a/content/en/methods/directory.md
+++ b/content/en/methods/directory.md
@@ -3,7 +3,6 @@ title: directory API methods
 description: A directory of profiles that your website is aware of.
 menu:
   docs:
-    weight: 20
     name: directory
     parent: methods-instance
     identifier: methods-directory

--- a/content/en/methods/domain_blocks.md
+++ b/content/en/methods/domain_blocks.md
@@ -3,7 +3,6 @@ title: domain_blocks API methods
 description: Manage a user's blocked domains.
 menu:
   docs:
-    weight: 50
     name: domain_blocks
     parent: methods-accounts
     identifier: methods-domain_blocks

--- a/content/en/methods/emails.md
+++ b/content/en/methods/emails.md
@@ -3,7 +3,6 @@ title: emails API methods
 description: Request a new confirmation email, potentially to a new email address.
 menu:
   docs:
-    weight: 20
     name: emails
     parent: methods-apps
     identifier: methods-emails

--- a/content/en/methods/endorsements.md
+++ b/content/en/methods/endorsements.md
@@ -3,7 +3,6 @@ title: endorsements API methods
 description: Feature other profiles on your own profile. See also accounts/:id/{pin,unpin}
 menu:
   docs:
-    weight: 90
     name: endorsements
     parent: methods-accounts
     identifier: methods-endorsements

--- a/content/en/methods/favourites.md
+++ b/content/en/methods/favourites.md
@@ -3,7 +3,6 @@ title: favourites API methods
 description: View your favourites. See also statuses/:id/{favourite,unfavourite}
 menu:
   docs:
-    weight: 20
     name: favourites
     parent: methods-accounts
     identifier: methods-favourites

--- a/content/en/methods/featured_tags.md
+++ b/content/en/methods/featured_tags.md
@@ -3,7 +3,6 @@ title: featured_tags API methods
 description: Feature tags that you use frequently on your profile.
 menu:
   docs:
-    weight: 100
     name: featured_tags
     parent: methods-accounts
     identifier: methods-featured_tags

--- a/content/en/methods/filters.md
+++ b/content/en/methods/filters.md
@@ -3,7 +3,6 @@ title: filters API methods
 description: Create and manage filters.
 menu:
   docs:
-    weight: 60
     name: filters
     parent: methods-accounts
     identifier: methods-filters

--- a/content/en/methods/follow_requests.md
+++ b/content/en/methods/follow_requests.md
@@ -3,7 +3,6 @@ title: follow_requests API methods
 description: View and manage follow requests.
 menu:
   docs:
-    weight: 80
     name: follow_requests
     parent: methods-accounts
     identifier: methods-follow_requests

--- a/content/en/methods/followed_tags.md
+++ b/content/en/methods/followed_tags.md
@@ -3,7 +3,6 @@ title: followed_tags API methods
 description: View your followed hashtags.
 menu:
   docs:
-    weight: 120
     name: followed_tags
     parent: methods-accounts
     identifier: methods-followed_tags

--- a/content/en/methods/grouped_notifications.md
+++ b/content/en/methods/grouped_notifications.md
@@ -3,7 +3,6 @@ title: Grouped notifications API methods
 description: Receive grouped notifications for activity on your account or statuses.
 menu:
   docs:
-    weight: 50
     name: grouped notifications
     parent: methods
     identifier: methods-grouped-notifications

--- a/content/en/methods/health.md
+++ b/content/en/methods/health.md
@@ -3,7 +3,6 @@ title: health API methods
 description: Check the health of the web process for the instance.
 menu:
   docs:
-    weight: 70
     name: health
     parent: methods
     identifier: methods-health

--- a/content/en/methods/instance.md
+++ b/content/en/methods/instance.md
@@ -3,7 +3,6 @@ title: instance API methods
 description: Discover information about a Mastodon server.
 menu:
   docs:
-    weight: 70
     name: instance
     parent: methods
     identifier: methods-instance

--- a/content/en/methods/lists.md
+++ b/content/en/methods/lists.md
@@ -5,7 +5,6 @@ description: >-
   timeline.
 menu:
   docs:
-    weight: 20
     name: lists
     parent: methods-timelines
     identifier: methods-lists

--- a/content/en/methods/markers.md
+++ b/content/en/methods/markers.md
@@ -3,7 +3,6 @@ title: markers API methods
 description: Save and restore your position in timelines.
 menu:
   docs:
-    weight: 30
     name: markers
     parent: methods-timelines
     identifier: methods-markers

--- a/content/en/methods/media.md
+++ b/content/en/methods/media.md
@@ -5,7 +5,6 @@ description: >-
   Attachments for more information about size and format limits.
 menu:
   docs:
-    weight: 10
     name: media
     parent: methods-statuses
     identifier: methods-media

--- a/content/en/methods/mutes.md
+++ b/content/en/methods/mutes.md
@@ -3,7 +3,6 @@ title: mutes API methods
 description: View your mutes. See also accounts/:id/{mute,unmute}
 menu:
   docs:
-    weight: 30
     name: mutes
     parent: methods-accounts
     identifier: methods-mutes

--- a/content/en/methods/notifications.md
+++ b/content/en/methods/notifications.md
@@ -3,7 +3,6 @@ title: notifications API methods
 description: Receive notifications for activity on your account or statuses.
 menu:
   docs:
-    weight: 50
     name: notifications
     parent: methods
     identifier: methods-notifications

--- a/content/en/methods/oauth.md
+++ b/content/en/methods/oauth.md
@@ -3,7 +3,6 @@ title: OAuth API methods
 description: Generate and manage OAuth tokens.
 menu:
   docs:
-    weight: 10
     name: oauth
     parent: methods-apps
     identifier: methods-oauth

--- a/content/en/methods/oembed.md
+++ b/content/en/methods/oembed.md
@@ -3,7 +3,6 @@ title: oembed API methods
 description: For generating OEmbed previews.
 menu:
   docs:
-    weight: 110
     name: oembed
     parent: methods
     identifier: methods-oembed

--- a/content/en/methods/polls.md
+++ b/content/en/methods/polls.md
@@ -5,7 +5,6 @@ description: >-
   need to GET a Status first and then check for a `poll` property.
 menu:
   docs:
-    weight: 20
     name: polls
     parent: methods-statuses
     identifier: methods-polls

--- a/content/en/methods/preferences.md
+++ b/content/en/methods/preferences.md
@@ -3,7 +3,6 @@ title: preferences API methods
 description: Preferred common behaviors to be shared across clients.
 menu:
   docs:
-    weight: 110
     name: preferences
     parent: methods-accounts
     identifier: methods-preferences

--- a/content/en/methods/profile.md
+++ b/content/en/methods/profile.md
@@ -3,7 +3,6 @@ title: profile API methods
 description: Methods concerning profiles.
 menu:
   docs:
-    weight: 20
     name: profile
     parent: methods
     identifier: methods-profile

--- a/content/en/methods/proofs.md
+++ b/content/en/methods/proofs.md
@@ -3,7 +3,6 @@ title: proofs API methods
 description: For use by identity providers.
 menu:
   docs:
-    weight: 100
     name: proofs
     parent: methods
     identifier: methods-proofs

--- a/content/en/methods/push.md
+++ b/content/en/methods/push.md
@@ -5,7 +5,6 @@ description: >-
   received, via the Web Push API
 menu:
   docs:
-    weight: 10
     name: push
     parent: methods-notifications
     identifier: methods-push

--- a/content/en/methods/reports.md
+++ b/content/en/methods/reports.md
@@ -3,7 +3,6 @@ title: reports API methods
 description: Report problematic users to your moderators.
 menu:
   docs:
-    weight: 70
     name: reports
     parent: methods-accounts
     identifier: methods-reports

--- a/content/en/methods/scheduled_statuses.md
+++ b/content/en/methods/scheduled_statuses.md
@@ -3,7 +3,6 @@ title: scheduled_statuses API methods
 description: Manage statuses that were scheduled to be published at a future date.
 menu:
   docs:
-    weight: 30
     name: scheduled_statuses
     parent: methods-statuses
     identifier: methods-scheduled_statuses

--- a/content/en/methods/search.md
+++ b/content/en/methods/search.md
@@ -3,7 +3,6 @@ title: search API methods
 description: Search for content in accounts, statuses and hashtags.
 menu:
   docs:
-    weight: 60
     name: search
     parent: methods
     identifier: methods-search

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -1,10 +1,8 @@
-
 ---
 title: statuses API methods
 description: Publish, interact, and view information about statuses.
 menu:
   docs:
-    weight: 30
     name: statuses
     parent: methods
     identifier: methods-statuses

--- a/content/en/methods/streaming.md
+++ b/content/en/methods/streaming.md
@@ -5,7 +5,6 @@ description: >-
   connection or via WebSocket.
 menu:
   docs:
-    weight: 40
     name: streaming
     parent: methods-timelines
     identifier: methods-streaming

--- a/content/en/methods/suggestions.md
+++ b/content/en/methods/suggestions.md
@@ -5,7 +5,6 @@ description: >-
   interactions.
 menu:
   docs:
-    weight: 120
     name: suggestions
     parent: methods-accounts
     identifier: methods-suggestions

--- a/content/en/methods/tags.md
+++ b/content/en/methods/tags.md
@@ -3,7 +3,6 @@ title: tags API methods
 description: View information about or follow/unfollow hashtags.
 menu:
   docs:
-    weight: 120
     name: tags
     parent: methods-accounts
     identifier: methods-tags

--- a/content/en/methods/timelines.md
+++ b/content/en/methods/timelines.md
@@ -3,7 +3,6 @@ title: timelines API methods
 description: Read and view timelines of statuses.
 menu:
   docs:
-    weight: 40
     name: timelines
     parent: methods
     identifier: methods-timelines

--- a/content/en/methods/trends.md
+++ b/content/en/methods/trends.md
@@ -3,7 +3,6 @@ title: trends API methods
 description: Listings of tags, statuses, and links with increased activity
 menu:
   docs:
-    weight: 10
     name: trends
     parent: methods-instance
     identifier: methods-trends


### PR DESCRIPTION
Not sure if there was a system to the old order, but this seems easier to navigate.