### PR TITLE
Add documentation for notification fallbacks

### DIFF
--- a/content/en/entities/Notification.md
+++ b/content/en/entities/Notification.md
@@ -100,7 +100,7 @@ aliases: [
 
 #### `fallback` {{%optional%}}
 
-**Description:** Fallback information available for some notification types that client may not support. Only available for some notification types, and only if the `supported_types` parameter is used when querying.
+**Description:** Fallback information available for some notification types that clients may not support. Only available for some notification types, and only if the `supported_types` parameter is used when querying.\
 **Type:** [NotificationFallback]({{< relref "entitites/NotificationFallback" >}})\
 **Version history:**\
 4.6.0 - added

--- a/content/en/entities/Notification.md
+++ b/content/en/entities/Notification.md
@@ -98,6 +98,13 @@ aliases: [
 **Version history:**\
 4.3.0 - added
 
+#### `fallback` {{%optional%}}
+
+**Description:** Fallback information available for some notification types that client may not support. Only available for some notification types, and only if the `supported_types` parameter is used when querying.
+**Type:** [NotificationFallback]({{< relref "entitites/NotificationFallback" >}})\
+**Version history:**\
+4.6.0 - added
+
 ## Examples
 
 ### Mention

--- a/content/en/entities/NotificationFallback.md
+++ b/content/en/entities/NotificationFallback.md
@@ -15,21 +15,21 @@ aliases: [
 ### `title`
 
 **Description:** Localized fallback title for the notification, for instance “Alice added you to a collection”.\
-**Type:** String\
+**Type:** String (HTML)\
 **Version history:**\
 4.6.0 - added
 
 ### `summary`
 
 **Description:** Localized fallback summary for the notification, for instance “You're on an app that does not support the most recent version of Mastodon. Sign in to the Mastodon web app for full functionality.”\
-**Type:** {{<nullable>}} String\
+**Type:** {{<nullable>}} String (HTML)\
 **Version history:**\
 4.6.0 - added
 
 ### `details`
 
 **Description:** Localized details for the notifications, to be displayed when clicking the notification, for instance.\
-**Type:** {{<nullable>}} String\
+**Type:** {{<nullable>}} String (HTML)\
 **Version history:**\
 4.6.0 - added
 

--- a/content/en/entities/NotificationFallback.md
+++ b/content/en/entities/NotificationFallback.md
@@ -1,0 +1,43 @@
+---
+title: Notification
+description: Represents a notification of an event relevant to the user.
+menu:
+  docs:
+    parent: entities
+aliases: [
+  "/entities/NotificationFallback",
+  "/api/entities/NotificationFallback",
+]
+---
+
+## Attributes
+
+### `title`
+
+**Description:** Localized fallback title for the notification, for instance “Alice added you to a collection”.\
+**Type:** String\
+**Version history:**\
+4.6.0 - added
+
+### `summary`
+
+**Description:** Localized fallback summary for the notification, for instance “You're on an app that does not support the most recent version of Mastodon. Sign in to the Mastodon web app for full functionality.”\
+**Type:** {{<nullable>}} String\
+**Version history:**\
+4.6.0 - added
+
+### `details`
+
+**Description:** Localized details for the notifications, to be displayed when clicking the notification, for instance.\
+**Type:** {{<nullable>}} String\
+**Version history:**\
+4.6.0 - added
+
+## See also
+
+{{< page-relref ref="methods/notifications" caption="notifications API methods" >}}
+
+{{< caption-link url="https://github.com/mastodon/mastodon/blob/main/app/serializers/concerns/notification_fallback_concern.rb" caption="app/serializers/concerns/notification_fallback_concern.rb" >}}
+
+
+

--- a/content/en/entities/NotificationFallback.md
+++ b/content/en/entities/NotificationFallback.md
@@ -1,5 +1,5 @@
 ---
-title: Notification
+title: NotificationFallback
 description: Represents a notification of an event relevant to the user.
 menu:
   docs:

--- a/content/en/methods/grouped_notifications.md
+++ b/content/en/methods/grouped_notifications.md
@@ -610,7 +610,7 @@ TODO
 
 #### `fallback` {{%optional%}}
 
-**Description:** Fallback information available for some notification types that client may not support. Only available for some notification types, and only if the `supported_types` parameter is used when querying.
+**Description:** Fallback information available for some notification types that clients may not support. Only available for some notification types, and only if the `supported_types` parameter is used when querying.\
 **Type:** [NotificationFallback]({{< relref "entitites/NotificationFallback" >}})\
 **Version history:**\
 4.6.0 - added

--- a/content/en/methods/grouped_notifications.md
+++ b/content/en/methods/grouped_notifications.md
@@ -48,7 +48,8 @@ Types to filter include:
 **OAuth:** User token + `read:notifications`\
 **Version history:**\
 4.3.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 2) - added\
-4.4.0 - added `admin.sign_up` to grouped notification types
+4.4.0 - added `admin.sign_up` to grouped notification types\
+4.6.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 10) - added `supported_types` optional parameter
 
 #### Request
 
@@ -88,6 +89,9 @@ grouped_types[]
 
 include_filtered
 : Boolean. Whether to include notifications filtered by the user's [NotificationPolicy]({{< relref "entities/NotificationPolicy" >}}). Defaults to false.
+
+supported_types[]
+: Array of String. Notification types to not get fallback representation for even when some is available. Passing this parameter is required to get any notification fallback at all. When this parameter is used, and a notification which type is *not* included in `supported_types` has an available fallback representation, it will be included in the notification group's `fallback` attribute.
 
 #### Response
 
@@ -214,7 +218,8 @@ View information about a specific notification group with a given group key.
 **Returns:** [GroupedNotificationsResults](#GroupedNotificationsResults)\
 **OAuth:** User token + `read:notifications`\
 **Version history:**\
-4.3.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 2) - added
+4.3.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 2) - added\
+4.6.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 10) - added `supported_types` optional parameter
 
 #### Request
 
@@ -227,6 +232,11 @@ View information about a specific notification group with a given group key.
 
 Authorization
 : {{<required>}} Provide this header with `Bearer <user token>` to gain authorized access to this API method.
+
+##### Query parameters
+
+supported_types[]
+: Array of String. Notification types to not get fallback representation for even when some is available. Passing this parameter is required to get any notification fallback at all. When this parameter is used, and a notification which type is *not* included in `supported_types` has an available fallback representation, it will be included in the notification group's `fallback` attribute.
 
 #### Response
 
@@ -597,6 +607,13 @@ TODO
 **Type:** [AccountWarning]({{< relref "entities/AccountWarning" >}})\
 **Version history:**\
 4.3.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 2) - added
+
+#### `fallback` {{%optional%}}
+
+**Description:** Fallback information available for some notification types that client may not support. Only available for some notification types, and only if the `supported_types` parameter is used when querying.
+**Type:** [NotificationFallback]({{< relref "entitites/NotificationFallback" >}})\
+**Version history:**\
+4.6.0 - added
 
 ### Examples
 

--- a/content/en/methods/notifications.md
+++ b/content/en/methods/notifications.md
@@ -47,7 +47,8 @@ Types to filter include:
 3.5.0 - added `types`; add `update` and `admin.sign_up` types\
 4.0.0 - added `admin.report` type\
 4.1.0 - notification limit changed from 15 (max 30) to 40 (max 80)\
-4.3.0 - added `include_filtered` parameter
+4.3.0 - added `include_filtered` parameter\
+4.6.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 10) - added `supported_types` optional parameter
 
 #### Request
 
@@ -81,6 +82,9 @@ account_id
 
 include_filtered
 : Boolean. Whether to include notifications filtered by the user's [NotificationPolicy]({{< relref "entities/NotificationPolicy" >}}). Defaults to false.
+
+supported_types[]
+: Array of String. Notification types to not get fallback representation for even when some is available. Passing this parameter is required to get any notification fallback at all. When this parameter is used, and a notification which type is *not* included in `supported_types` has an available fallback representation, it will be included in the notification's `fallback` attribute.
 
 #### Response
 
@@ -187,7 +191,8 @@ View information about a notification with a given ID.
 **Returns:** [Notification]({{< relref "entities/Notification" >}})\
 **OAuth:** User token + `read:notifications`\
 **Version history:**\
-0.0.0 - added
+0.0.0 - added\
+4.6.0 (`mastodon` [API version]({{< relref "entities/Instance#api-versions" >}}) 10) - added `supported_types` optional parameter
 
 #### Request
 
@@ -200,6 +205,11 @@ View information about a notification with a given ID.
 
 Authorization
 : {{<required>}} Provide this header with `Bearer <user_token>` to gain authorized access to this API method.
+
+##### Query parameters
+
+supported_types[]
+: Array of String. Notification types to not get fallback representation for even when some is available. Passing this parameter is required to get any notification fallback at all. When this parameter is used, and a notification which type is *not* included in `supported_types` has an available fallback representation, it will be included in the notification's `fallback` attribute.
 
 #### Response
 


### PR DESCRIPTION
This adds documentation for the notification fallback functionality added in https://github.com/mastodon/mastodon/pull/38832

The documentation mentions the yet-unused Mastodon API version 10 because API version 9 cannot guarantee the functionality is available, but it will be available starting with API version 10, which will include collections.