### PR TITLE
Install guide: update dependencies

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -28,15 +28,7 @@ apt install -y curl wget gnupg lsb-release ca-certificates
 #### Node.js {#node-js}
 
 ```bash
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-```
-
-#### PostgreSQL {#postgresql}
-
-```bash
-wget -O /usr/share/keyrings/postgresql.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc
-echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/postgresql.list
+curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
 ```
 
 ### System packages {#system-packages}
@@ -44,7 +36,7 @@ echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] http://apt.postgresql.o
 ```bash
 apt update
 apt install -y \
-  imagemagick ffmpeg libvips-tools libpq-dev libxslt1-dev file git \
+  ffmpeg libvips-tools libpq-dev libxslt1-dev file git \
   protobuf-compiler pkg-config autoconf bison build-essential \
   libssl-dev libyaml-dev libreadline-dev zlib1g-dev libffi-dev \
   libgdbm-dev nginx nodejs redis-server postgresql certbot \


### PR DESCRIPTION
This brings the installation guide in line with Mastodon's required server OS and dependency versions. As a bonus, this change at least partially fixes #1901. Updated steps tested and verified with Ubuntu 26.04LTS and Mastodon 4.5.10.

- Removed `imagemagick` from the list of packages to install, since it has been deprecated for a long time, and support was [removed](https://github.com/mastodon/mastodon/pull/37488) earlier this year. Ubuntu 24.04 and Debian 13 both include the minimum required version of `libvips-tools`.
- Removed the instructions for installing PostgreSQL upstream's `postgresql`, which are unnecessary, since the required versions of Ubuntu and Debian both ship much more recent versions than the minimum `postgresql 14` version listed in the [release notes](https://github.com/mastodon/mastodon/releases). Installing the distribution's `postgresql` package is all that's needed.
- Simplified the instructions for adding the upstream NodeJS repository. Upstream's CLI one-liner fetched by this step already adds the `gpg` key and the package repo, using the modern DEB822 `.sources` format (and standardized in Ubuntu 24.04), instead of the deprecated `.list` format.