### PR TITLE
Add 'disabled' status to FeatureApproval documentation

### DIFF
--- a/content/en/entities/FeatureApproval.md
+++ b/content/en/entities/FeatureApproval.md
@@ -29,6 +29,7 @@ aliases: [
 `followers` = Followers are expected to be able to feature this account in a Collection and have this accepted automatically.\
 `following` = People followed by this account are expected to be able to to feature it in a Collection and have this accepted automatically.\
 `unsupported_policy` = The underlying policy is not supported by Mastodon. Some accounts that do not fit in the above categories may be allowed to feature this account in a Collection and have this accepted automatically.\
+`disabled` = All interaction explicitly disabled.\
 **Version history:**\
 4.6.0 - added
 


### PR DESCRIPTION
Add [`disabled`](https://github.com/mastodon/mastodon/blob/ead13d4826a7ba1699d6bb310e58642b15687671/app/lib/interaction_policy.rb#L9) as a possible value.

[Example](https://mastodon.social/api/v1/accounts/109321630558231166) 

```
{
  "id": "109321630558231166",
  "username": "curiousrobot",
  "acct": "curiousrobot@infosec.exchange",
  "display_name": "T",
  "locked": true,
  "bot": false,
  "discoverable": false,
  "indexable": false,
  "group": false,
  "created_at": "2022-11-10T00:00:00.000Z",
  "note": "\u003Cp\u003ERecovering systems/network maintainer and fixer. Current status: \u003Ca href=\"https://infosec.exchange/tags/cybersecurity\" class=\"mention hashtag\" rel=\"nofollow noopener\" target=\"_blank\"\u003E#\u003Cspan\u003Ecybersecurity\u003C/span\u003E\u003C/a\u003E janitor. Clearly Canadian.\u003C/p\u003E",
  "url": "https://infosec.exchange/@curiousrobot",
  "uri": "https://infosec.exchange/users/curiousrobot",
  "avatar": "https://files.mastodon.social/cache/accounts/avatars/109/321/630/558/231/166/original/0e23ab1bf110a9a4.png",
  "avatar_static": "https://files.mastodon.social/cache/accounts/avatars/109/321/630/558/231/166/original/0e23ab1bf110a9a4.png",
  "avatar_description": "",
  "header": "https://files.mastodon.social/cache/accounts/headers/109/321/630/558/231/166/original/ff0904836a70d861.jpg",
  "header_static": "https://files.mastodon.social/cache/accounts/headers/109/321/630/558/231/166/original/ff0904836a70d861.jpg",
  "header_description": "",
  "followers_count": 260,
  "following_count": 684,
  "statuses_count": 203,
  "last_status_at": "2026-06-07",
  "hide_collections": true,
  "show_media": true,
  "show_media_replies": true,
  "show_featured": true,
  "feature_approval": {
    "automatic": [
      "disabled"
    ],
    "manual": [],
    "current_user": "denied"
  },
  "emojis": [],
  "fields": []
}
```