### PR TITLE
Fix typo in the Collections entity example

### DIFF
--- a/content/en/entities/Collection.md
+++ b/content/en/entities/Collection.md
@@ -205,7 +205,7 @@ This wraps a list of [Collection]({{< relref "entities/Collection" >}}) entities
       // ...
     },
     // ...
-  }
+  ]
 }
 ```
 


### PR DESCRIPTION
The array wasn't closed with a `]` but with a `}`