### PR TITLE
Add documentation for ScheduledStatus quotes

### DIFF
--- a/content/en/client/quotes.md
+++ b/content/en/client/quotes.md
@@ -16,6 +16,8 @@ The new APIs described below are available starting with `mastodon` [API version
 - the [Status]({{< relref "entities/status" >}}) entity has a new `quote_approval` attribute, holding a [QuoteApproval]({{< relref "entities/QuoteApproval" >}}) entity
 - the [Status]({{< relref "entities/status" >}}) entity also has an additional `quotes_count` attribute counting the number of accepted quotes
 - the [CredentialAccount]({{< relref "entities/Account#CredentialAccount">}}) entity has an additional `source[quote_policy]` attribute holding the default quote policy for the user. One of `public`, `followers` and `nobody`
+- the [ScheduledStatus]({{< relref "entities/scheduledstatus" >}}) entity has a new `params[quoted_status_id]` attribute, holding the ID of the status being quoted
+- the [ScheduledStatus]({{< relref "entities/scheduledstatus" >}}) entity also has a new `params[quote_approval_policy]` attribute, holding the quote policy for the status. One of `public`, `followers` and `nobody`.
 - the response to [`GET /api/v1/preferences`]({{< relref "methods/preferences#get" >}}) has a new attribute `posting:default:quote_policy` holding the default quote policy for the user. One of `public`, `followers` and `nobody`.
 
 ### New notification types

--- a/content/en/entities/ScheduledStatus.md
+++ b/content/en/entities/ScheduledStatus.md
@@ -32,7 +32,9 @@ Returned from `POST /api/v1/statuses?status=test post&scheduled_at=2022-09-29`
     "idempotency": null,
     "with_rate_limit": false,
     "in_reply_to_id": null,
-    "application_id": 3
+    "application_id": 3,
+    "quoted_status_id": null,
+    "quote_approval_policy": "followers"
   },
   "media_attachments": []
 }
@@ -56,7 +58,9 @@ Returned from `GET /api/v1/scheduled_statuses`:
     "spoiler_text": null,
     "application_id": 3,
     "in_reply_to_id": null,
-    "with_rate_limit": false
+    "with_rate_limit": false,
+    "quoted_status_id": null,
+    "quote_approval_policy": "followers"
   },
   "media_attachments": []
 }
@@ -193,6 +197,23 @@ Returned from `GET /api/v1/scheduled_statuses`:
 **Type:** {{<nullable>}} String\
 **Version history:**\
 2.7.0 - added
+
+#### `params[quoted_status_id]` {#params-quoted_status_id}
+
+**Description:** ID of the Status being quoted.\
+**Type:** {{<nullable>}} String (cast from an integer, but not guaranteed to be a number)\
+**Version history:**\
+4.5.0 - added
+
+#### `params[quote_approval_policy]` {#params-quote_approval_policy}
+
+**Description:** The quote policy for the Status.\
+**Type:** String (Enumerable, oneOf)\
+`public` = Anyone (except blocked accounts) can quote\
+`followers` = Only followers and author can quote\
+`nobody` = Only author can quote\
+**Version history:**\
+4.5.0 - added
 
 #### `params[with_rate_limit]` {{%deprecated%}} {#params-with_rate_limit}
 

--- a/content/en/methods/scheduled_statuses.md
+++ b/content/en/methods/scheduled_statuses.md
@@ -68,7 +68,9 @@ limit
       "scheduled_at": null,
       "spoiler_text": null,
       "application_id": 596551,
-      "in_reply_to_id": null
+      "in_reply_to_id": null,
+      "quoted_status_id": null,
+      "quote_approval_policy": "followers"
     },
     "media_attachments": []
   }
@@ -127,7 +129,9 @@ Authorization
     "scheduled_at": null,
     "spoiler_text": null,
     "application_id": 596551,
-    "in_reply_to_id": null
+    "in_reply_to_id": null,
+    "quoted_status_id": null,
+    "quote_approval_policy": "followers"
   },
   "media_attachments": []
 }
@@ -200,7 +204,9 @@ scheduled_at
     "scheduled_at": null,
     "spoiler_text": null,
     "application_id": 596551,
-    "in_reply_to_id": null
+    "in_reply_to_id": null,
+    "quoted_status_id": null,
+    "quote_approval_policy": "followers"
   },
   "media_attachments": []
 }

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -125,7 +125,9 @@ If scheduled_at is provided, then a ScheduledStatus will be returned instead:
     "poll": null,
     "idempotency": null,
     "in_reply_to_id": null,
-    "application_id": 596551
+    "application_id": 596551,
+    "quoted_status_id": null,
+    "quote_approval_policy": "followers"
   },
   "media_attachments": []
 }


### PR DESCRIPTION
ScheduledStatus gained `params[quoted_status_id]` and `params[quote_approval_policy]`. This PR adds the attributes to the entity, adds them to the examples and adds them to the client quote support guide.

(yes `params[quoted_status_id]` is nullable string cast from int, unlike `in_reply_to_id`)

rel: https://github.com/mastodon/mastodon/issues/37014