### PR TITLE
Remove conflicting memory allocation instructions for Elasticsearch

### DIFF
--- a/content/en/admin/elasticsearch.md
+++ b/content/en/admin/elasticsearch.md
@@ -172,21 +172,6 @@ RAILS_ENV=production bin/tootctl search deploy
 
 {{< hint style="info" >}}
 Creating Elasticsearch indices could require more memory than the JVM (Java Virtual Machine) provides. If Elasticsearch crashes while creating indices, try to allocate more memory.
-
-1. Create and open a file in the directory ```/etc/elasticsearch/jvm.options.d/``` (for example: ```nano /etc/elasticsearch/jvm.options.d/ram.options```)
-2. Add following text and edit the allocated memory to your needs. As a rule of thumb, Elasticsearch should use about 25%-50% of your available memory. Do not allocate more memory than available.
-
-    ```java-properties
-    # Xms represents the initial size of total heap space
-    # Xmx represents the maximum size of total heap space
-    # Both values should be the same
-    -Xms2048m
-    -Xmx2048m
-    ```
-
-3. Save the file.
-4. Restart Elasticsearch using ```systemctl restart elasticsearch```.
-5. Retry creating Elasticsearch indices. If Elasticsearch still crashes, try to set a higher number.
 {{< /hint >}}
 
 ## Search optimization for other languages


### PR DESCRIPTION
PRs #1456 and #1468 add conflicting instructions to the Elasticsearch page when it comes to allocating memory

Initially we start with 16GB (pre) 24GB (max) at `/etc/elasticsearch/jvm.options.d/limit-ram.options`

But later we describe that if mastodon crashes during indices we should allocate "more" memory: 2GB (max) at `/etc/elasticsearch/jvm.options.d/ram.options`

This means that someone following this tutorial will actually reduce their memory allocation, and have their memory allocation defined twice, not sure which one is picked or if this works at all.

This PR removes the double instructions

Additionally I think the default of 24GB memory max is way too much, but out of scope of this PR :)