### PR TITLE
Indicate POST collections account_ids is an array

### DIFF
--- a/content/en/methods/collections.md
+++ b/content/en/methods/collections.md
@@ -71,7 +71,7 @@ sensitive
 discoverable
 : Boolean. Whether this Collection should appear on the user's profile, in search results and other discovery mechanisms
 
-account_ids
+account_ids[]
 : Array of String. IDs of the accounts to feature in this Collection
 
 #### Response


### PR DESCRIPTION
Array parameters for other endpoints include `[]` to help indicate it's an array.

https://docs.joinmastodon.org/methods/statuses/#form-data-parameters