### PR TITLE
WebPushSubscription#id is an integer

### DIFF
--- a/content/en/entities/WebPushSubscription.md
+++ b/content/en/entities/WebPushSubscription.md
@@ -39,7 +39,7 @@ aliases: [
 ### `id` {#id}
 
 **Description:** The ID of the Web Push subscription in the database.\
-**Type:** String (cast from an integer, but not guaranteed to be a number)\
+**Type:** Integer\
 **Version history:**\
 2.4.0 - added
 


### PR DESCRIPTION
It was maybe intended to be a string but there is no coercion happening.

https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/web_push_subscription_serializer.rb#L4